### PR TITLE
Improved join function in jscl.lisp

### DIFF
--- a/ecmalisp.lisp
+++ b/ecmalisp.lisp
@@ -903,15 +903,9 @@
 
 ;;; Concatenate a list of strings, with a separator
 (defun join (list &optional (separator ""))
-  (cond
-    ((null list)
-     "")
-    ((null (cdr list))
-     (car list))
-    (t
-     (concat (car list)
-             separator
-             (join (cdr list) separator)))))
+  (!reduce (lambda (s o) (concat s separator o))  
+           (cdr list) 
+           :initial-value (car list)))
 
 (defun join-trailing (list &optional (separator ""))
   (if (null list)


### PR DESCRIPTION
Replaced unnecessary recursive definition of join with more concise call to !reduce.
