### PR TITLE
Fix COND bug

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -213,14 +213,16 @@
 
 (defmacro cond (&rest clausules)
   (if (null clausules)
-      nil
-      (if (eq (caar clausules) t)
-        `(progn ,@(cdar clausules))
-        `(if ,(caar clausules)
-           ,(if (null (cdar clausules))
-              (caar clausules)
-              `(progn ,@(cdar clausules)))
-           (cond ,@(cdr clausules))))))
+    nil
+    (if (eq (caar clausules) t)
+      `(progn ,@(cdar clausules))
+      (let ((test-symbol (gensym)))
+        `(let ((,test-symbol ,(caar clausules)))
+           (if ,test-symbol
+             ,(if (null (cdar clausules))
+                test-symbol
+                `(progn ,@(cdar clausules)))
+             (cond ,@(cdr clausules))))))))
 
 (defmacro case (form &rest clausules)
   (let ((!form (gensym)))

--- a/tests/conditionals.lisp
+++ b/tests/conditionals.lisp
@@ -9,6 +9,9 @@
 ; COND
 (test (eql nil (cond)))
 (test (=   1   (cond (1))))
+(test (= 1
+         (let ((x 0))
+           (cond ((incf x))))))
 (test (=   2   (cond (1 2))))
 (test (=   3   (cond (nil 1) (2 3))))
 (test (eql nil (cond (nil 1) (nil 2))))


### PR DESCRIPTION
The test was evaluated twice for length 1 clauses. My bad, introduced it with that last fix.
