### PR TITLE
Make sure READ-FLOAT returns a float.

### DIFF
--- a/src/read.lisp
+++ b/src/read.lisp
@@ -229,7 +229,7 @@
             (incf index))))
       (unless (= index size) (return))
       ;; Everything went ok, we have a float
-      (/ (* sign (expt 10 (* exponent-sign exponent)) number) divisor))))
+      (float (/ (* sign (expt 10 (* exponent-sign exponent)) number) divisor) 1.0))))
 
 
 (defun !parse-integer (string junk-allow)


### PR DESCRIPTION
During cross-compilation, READ-FLOAT can return a rational. Instead force it to give a float.
