### PR TITLE
Make sure READ-FLOAT returns a float.

### DIFF
--- a/src/read.lisp
+++ b/src/read.lisp
@@ -229,7 +229,8 @@
             (incf index))))
       (unless (= index size) (return))
       ;; Everything went ok, we have a float
-      (/ (* sign (expt 10 (* exponent-sign exponent)) number) divisor))))
+      ;; XXX: Use FLOAT when implemented.
+      (/ (* sign (expt 10.0d0 (* exponent-sign exponent)) number) divisor))))
 
 
 (defun !parse-integer (string junk-allow)


### PR DESCRIPTION
Make sure READ-FLOAT returns a float during cross-compilation. (This strategy just embeds a float into the calculation as opposed to an explicit conversion.)
