### PR TITLE
Symbol quoting

### DIFF
--- a/tests/read.lisp
+++ b/tests/read.lisp
@@ -5,6 +5,10 @@
  (equal (multiple-value-list (read-from-string "(a b c)"))
         '((A B C) 7)))
 
+(test (equal (symbol-name (read-from-string "js:alert")) "alert"))
+(test (equal (symbol-name (read-from-string "cl:cond")) "COND"))
+(test (equal (symbol-name (read-from-string "co|N|d")) "COND"))
+(test (equal (symbol-name (read-from-string "abc\\def")) "ABCdEF"))
 (test (equal (symbol-name (read-from-string "|.|")) "."))
 (test (equal (read-from-string "(1 .25)") '(1 0.25)))
 (test (equal (read-from-string ".25") 0.25))


### PR DESCRIPTION
Added support for reading quoted symbols... for example

```
foo\:bar
|this is a test|
co|N|d
```

also fixed a few reader bugs like `(1 .25)` being read as `(1 . 25)`
