### PR TITLE
Fix #111, error with docstrings containing single quotes

### DIFF
--- a/src/compiler.lisp
+++ b/src/compiler.lisp
@@ -266,9 +266,9 @@
       (js!selfcall
         "var func = " (join strs) ";" *newline*
         (when name
-          (code "func.fname = '" (escape-string name) "';" *newline*))
+          (code "func.fname = \"" (escape-string name) "\";" *newline*))
         (when docstring
-          (code "func.docstring = '" (escape-string docstring) "';" *newline*))
+          (code "func.docstring = \"" (escape-string docstring) "\";" *newline*))
         "return func;" *newline*)
       (apply #'code strs)))
 

--- a/tests/defun.lisp
+++ b/tests/defun.lisp
@@ -1,0 +1,4 @@
+;;;; Tests for DEFUN
+
+;;; Regression test for #111
+(test (eql (defun foo () "foo's" ()) 'foo))


### PR DESCRIPTION
ESCAPE-STRING assumes the resulting string is going to be double-quoted,
and LAMBA-NAME/DOCSTRING-WRAPPER was only single quoting them.

A similar issue was present for function names with single quotes. These
should be read differently, i.e. FO'O => FO (QUOTE O), but until the
reader is fixed to deal with this I think allowing them in function
names makes more sense than failing with a strange error message
