### PR TITLE
Smarter escape-string

### DIFF
--- a/src/print.lisp
+++ b/src/print.lisp
@@ -194,7 +194,7 @@
                          (#\space "space")
                          (otherwise (string form)))))
               ((stringp form) (if *print-escape*
-                                  (escape-string form)
+                                  (lisp-escape-string form)
                                   form))
               ((functionp form)
                (let ((name (oget form "fname")))


### PR DESCRIPTION
Implements a fix for #114; use single or double quotes for string literals depending on the context
