### PR TITLE
Tiny DO/DO* bug fix

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -291,7 +291,9 @@
 
 (defmacro do (varlist endlist &body body)
   `(block nil
-     (let ,(mapcar (lambda (x) (list (first x) (second x))) varlist)
+     (let ,(mapcar (lambda (x) (if (symbolp x)
+                                   (list x nil)
+                                 (list (first x) (second x)))) varlist)
        (while t
          (when ,(car endlist)
            (return (progn ,@(cdr endlist))))
@@ -299,13 +301,16 @@
          (psetq
           ,@(apply #'append
                    (mapcar (lambda (v)
-                             (and (consp (cddr v))
+                             (and (listp v)
+                                  (consp (cddr v))
                                   (list (first v) (third v))))
                            varlist)))))))
 
 (defmacro do* (varlist endlist &body body)
   `(block nil
-     (let* ,(mapcar (lambda (x) (list (first x) (second x))) varlist)
+     (let* ,(mapcar (lambda (x1) (if (symbolp x1)
+                                     (list x1 nil)
+                                   (list (first x1) (second x1)))) varlist)
        (while t
          (when ,(car endlist)
            (return (progn ,@(cdr endlist))))
@@ -313,7 +318,8 @@
          (setq
           ,@(apply #'append
                    (mapcar (lambda (v)
-                             (and (consp (cddr v))
+                             (and (listp v)
+                                  (consp (cddr v))
                                   (list (first v) (third v))))
                            varlist)))))))
 

--- a/tests/iter-macros.lisp
+++ b/tests/iter-macros.lisp
@@ -12,15 +12,31 @@
         (= total 15)))
 
 ; DO
-(test (do ((a 0 b)                                 
-           (b 1 (+ a b))                                                          
-           (n 0 (1+ n)))                                                          
-        ((= n 10) 
+(test (do ((a 0 b)
+           (b 1 (+ a b))
+           (n 0 (1+ n)))
+        ((= n 10)
          (= a 55))))
+(test (= 5
+         (do (x) (t 5))))
+(test (= 5
+         (do ((x)) (t 5))))
+(test (= 5
+         (do ((x nil)) (t 5))))
+(test (= 5
+         (do ((x nil nil)) (t 5))))
 
 ; DO*
-(test (do* ((a 0 b)                                 
-            (b 1 (+ a b))                                                          
-            (n 0 (1+ n)))                                                          
-        ((= n 10) 
+(test (do* ((a 0 b)
+            (b 1 (+ a b))
+            (n 0 (1+ n)))
+        ((= n 10)
          (= a 512))))
+(test (= 5
+         (do* (x) (t 5))))
+(test (= 5
+         (do* ((x)) (t 5))))
+(test (= 5
+         (do* ((x nil)) (t 5))))
+(test (= 5
+         (do* ((x nil nil)) (t 5))))


### PR DESCRIPTION
I noticed that DO and DO\* didn't allow passing in raw symbols as vars, as in the Hyperspec docs, so I added this.  Cheers!
