### PR TITLE
Fixed min/max

### DIFF
--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -81,7 +81,7 @@
 (macrolet ((def (name comparison)
              `(defun ,name (x &rest xs)
                 (dolist (y xs) 
-                  (unless (,comparison x (car xs))
+                  (when (,comparison y x)
                     (setq x y)))
                 x)))
   (def max >)

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -8,11 +8,13 @@
 (test (= (max 1)     1))
 (test (= (max 1 2 3) 3))
 (test (= (max 3 2 1) 3))
+(test (= (max 1 2 3 4 5) 5))
 
 ;;; MIN
 (test (= (min 1)     1))
 (test (= (min 1 2 3) 1))
 (test (= (min 3 2 1) 1))
+(test (= (min 9 3 8 7 6 3 3) 3))
 
 ;;; EVENP
 (test      (evenp  2))


### PR DESCRIPTION
The min/max functions didn't work correctly for lists longer than 3 elements.
