### PR TITLE
Restore CONS evaluation on REPL

### DIFF
--- a/src/compiler/codegen.lisp
+++ b/src/compiler/codegen.lisp
@@ -167,7 +167,7 @@
     (js-format "]")))
 
 (defun js-object-initializer (plist)
-  (js-format "{")
+  (js-format "({")
   (do* ((tail plist (cddr tail)))
        ((null tail))
     (let ((key (car tail))
@@ -181,7 +181,7 @@
       (js-expr value no-comma)
       (unless (null (cddr tail))
         (js-format ","))))
-  (js-format "}"))
+  (js-format "})"))
 
 (defun js-function (arguments &rest body)
   (js-format "function(")


### PR DESCRIPTION
Now this is a tricky one.

CONS evaluates to error on REPL, too:

``` lisp
CL-USER> (cons 1 2)
Error occurred
```

That's because JavaScript EVAL interprets curly braces of object literals as
markers of a block of code. We can do this little trick by emitting an extra
pair of parens around object literals during code generation to avoid this.
