### PR TITLE
Add *VERBOSE* to enable printing of toplevel forms as they're compiled.

### DIFF
--- a/jscl.lisp
+++ b/jscl.lisp
@@ -23,6 +23,7 @@
 (in-package :jscl)
 
 (defvar *version* "0.0.2")
+(defvar *verbose* nil)
 
 (defvar *base-directory*
   (or #.*load-pathname* *default-pathname-defaults*))
@@ -129,6 +130,8 @@
          with eof-mark = (gensym)
          for x = (ls-read in nil eof-mark)
          until (eq x eof-mark)
+         when (and *verbose* (typep x 'list))
+           do (format t "  Compiling (~S ~S ...)~%" (first x) (second x))
          do (let ((compilation (compile-toplevel x)))
               (when (plusp (length compilation))
                 (write-string compilation out)))))))


### PR DESCRIPTION
This simply prints the first two elements of each toplevel form as they are compiled with `!COMPILE-FILE`. Since JSCL doesn't retain line number information, this makes errors easier to track down. Ideally this could be enabled with something like `./make.sh -v` but I couldn't be bothered for now.
