### PR TITLE
Implement SUBSTITUTE

### DIFF
--- a/src/sequence.lisp
+++ b/src/sequence.lisp
@@ -163,6 +163,19 @@
   (position-if (complement predicate) sequence
                :from-end from-end :key key :start start :end end))
 
+(defun substitute (new old seq 
+                   &key (key #'identity) (test #'eql))
+  (and seq
+       (map (cond
+              ((stringp seq) 'string)
+              ((vectorp seq) 'vector)
+              ((listp seq) 'list)) 
+            (lambda (elt)
+              (if (funcall test old (funcall key elt))
+                  new
+                  elt))
+            seq)))
+
 (defun remove (x seq &key key (test #'eql testp) (test-not #'eql test-not-p))
   (cond
     ((null seq)

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -41,6 +41,13 @@
 (test (find 2 (remove 2 #(1 2 3) :test-not #'=)))
 (test (find 2 (remove 2 '(1 2 3) :test-not #'=)))
 
+;; SUBSTITUTE
+(test (equal (substitute #\_ #\- "Hello-World") "Hello_World"))
+(test (equal (substitute 4 5 '(1 2 3 4)) '(1 2 3 4)))
+(test (equal (substitute 99 3 '(1 2 3 4)) '(1 2 99 4)))
+(test (equal (substitute 99 3 '(1 2 3 4) :test #'<=) '(1 2 99 99)))
+(test (equal (substitute 99 3 #(1 2 3 4) :test #'<=) #(1 2 99 99)))
+
 ; POSITION
 (test (= (position 1 #(1 2 3))  0))
 (test (= (position 1 '(1 2 3))  0))


### PR DESCRIPTION
This is a naïve and minimal implementation that covers my own needs, handling only list, vector, or string types and only the :TEST and :KEY keyword (no others).

Example (in JSCL REPL):

CL-USER> (substitute #\\_ #\\- "Hello-World")
"Hello_World"
CL-USER> (substitute 4 5 '(1 2 3 4))
(1 2 3 4)
CL-USER> (substitute 99 3 '(1 2 3 4))
(1 2 99 4)
CL-USER> (substitute 99 3 '(1 2 3 4) :test #'<=)
(1 2 99 99)
CL-USER> (substitute 99 3 #(1 2 3 4) :test #'<=)
#(1 2 99 99)