### PR TITLE
Reader char literals fix

### DIFF
--- a/src/read.lisp
+++ b/src/read.lisp
@@ -261,9 +261,14 @@
               (concat (string (%read-char stream))
                       (read-until stream #'terminalp))))
          (cond
-           ((string= cname "space") #\space)
-           ((string= cname "tab") #\tab)
-           ((string= cname "newline") #\newline)
+           ((string-equal cname "space") #\space)
+           ((string-equal cname "tab") #\tab)
+           ((string-equal cname "newline") #\newline)
+           ((string-equal cname "linefeed") #\linefeed)
+           ((string-equal cname "return") #\return)
+           ((string-equal cname "page") #\page)
+           ((string-equal cname "backspace") #\backspace)
+           ((string-equal cname "rubout") #\rubout)
            (t (char cname 0)))))
       ((#\+ #\-)
        (let* ((expression

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -264,11 +264,6 @@
            ((string-equal cname "space") #\space)
            ((string-equal cname "tab") #\tab)
            ((string-equal cname "newline") #\newline)
-           ((string-equal cname "linefeed") #\linefeed)
-           ((string-equal cname "return") #\return)
-           ((string-equal cname "page") #\page)
-           ((string-equal cname "backspace") #\backspace)
-           ((string-equal cname "rubout") #\rubout)
            (t (char cname 0)))))
       ((#\+ #\-)
        (let* ((expression

--- a/tests/read.lisp
+++ b/tests/read.lisp
@@ -48,3 +48,6 @@
 (test (= (read-from-string "#| #| |# |# 2")  2))
 (test (= (read-from-string "#|#$#%^&*&|# 2") 2))
 (test (= (read-from-string "#|||# 2")        2))
+
+;; character literals
+(test (char= #\SPACE #\Space #\space))


### PR DESCRIPTION
This fixes #240 (#\SPACE #\Space #\space) in the narrowest sense, for space, tab, newline only; the other issue which that exposed, of not escaping control chars, remains an issue to examine later.