### PR TITLE
Add a MAKE-NEW operator to construct Javascript objects.

### DIFF
--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1255,21 +1255,8 @@
   '(object))
 
 (define-raw-builtin make-new (constructor-function &rest constructor-args)
-  (let ((args (butlast constructor-args))
-        (last (car (last constructor-args))))
-    `(selfcall
-      (var (ctor ,(convert constructor-function)))
-      (var (args ,(list-to-vector
-                   (cons (if *multiple-value-p* '|values| '(internal |pv|))
-                         (mapcar #'convert args)))))
-      (var (tail ,(convert last)))
-      (while (!= tail ,(convert nil))
-        (method-call args "push" (get tail "car"))
-        (= tail (get tail "cdr")))
-      (new (call (if (=== (typeof ctor) "function")
-                     ctor
-                     (get ctor "fvalue"))
-                 args)))))
+  `(selfcall 
+    (return (new (call ,constructor-function  ,@(mapcar #'convert constructor-args))))))
 
 (define-raw-builtin oget* (object key &rest keys)
   `(selfcall

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1254,6 +1254,23 @@
 (define-builtin new ()
   '(object))
 
+(define-raw-builtin make-new (constructor-function &rest constructor-args)
+  (let ((args (butlast constructor-args))
+        (last (car (last constructor-args))))
+    `(selfcall
+      (var (ctor ,(convert constructor-function)))
+      (var (args ,(list-to-vector
+                   (cons (if *multiple-value-p* '|values| '(internal |pv|))
+                         (mapcar #'convert args)))))
+      (var (tail ,(convert last)))
+      (while (!= tail ,(convert nil))
+        (method-call args "push" (get tail "car"))
+        (= tail (get tail "cdr")))
+      (new (call (if (=== (typeof ctor) "function")
+                     ctor
+                     (get ctor "fvalue"))
+                 args)))))
+
 (define-raw-builtin oget* (object key &rest keys)
   `(selfcall
     (progn


### PR DESCRIPTION
Usage: (make-new |ConstructorName| arg₀ … )

I actually anticipated this to be way more complicated than it came out, but

CL-USER> (#j:console:log (jscl::make-new |Date| 1 2 3 4 5 6))
#<javascript object>

Date 1901-03-03T08:05:06.000Z → inspectable object with all the methods and goodies.⁂(PS *as below: except magic [[PrimitiveValue]]*.)

CL-USER> ((jscl::oget (jscl::make-new |Date| 1 2 3 4 5 6) "getTime"))
-2172153294000