### PR TITLE
Throw detailed `Error` objects

### DIFF
--- a/jscl.lisp
+++ b/jscl.lisp
@@ -129,9 +129,21 @@
 
 (defun read-whole-file (filename)
   (with-open-file (in filename)
-    (let ((seq (make-array (file-length in) :element-type 'character)))
+    ;; FILE-LENGTH is  in bytes, not  characters. UTF-8 characters will  yield a shorter  read, with
+    ;; trailing  #\NULL bytes,  unless  we initialize  to  spaces. It's  a hack,  but  it's a  cheap
+    ;; enough one.
+    (let ((seq (make-string (file-length in) :initial-element #\space)))
       (read-sequence seq in)
       seq)))
+
+(defun possibly-valid-js-p (string)
+  (if (characterp string)
+      (or (graphic-char-p string)
+          (char= #\newline string))
+      (every (lambda (ch)
+               (or (graphic-char-p ch)
+                   (char= #\newline ch)))
+             string)))
 
 (defun !compile-file (filename out &key print)
   (let ((*compiling-file* t)
@@ -145,8 +157,12 @@
          for x = (ls-read in nil eof-mark)
          until (eq x eof-mark)
          do (let ((compilation (compile-toplevel x)))
-              (when (plusp (length compilation))
-                (write-string compilation out)))))))
+              (if (possibly-valid-js-p compilation)
+                  (when (plusp (length compilation))
+                    (write-string compilation out))
+                  (error "Generated illegal characters (first is ~@c)~%Compiling form:~%~S~%from ~s~%Generated:~%~s"
+                         (find-if (complement #'possibly-valid-js-p) compilation) 
+                         x in compilation)))))))
 
 (defun dump-global-environment (stream)
   (flet ((late-compile (form)

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -412,7 +412,7 @@
 
 ;;; Early error definition.
 (defun error (fmt &rest args)
-  (%throw (apply #'format nil fmt args)))
+  (%throw (make-new |Error| (apply #'format nil fmt args))))
 
 (defmacro nth-value (n form)
   `(multiple-value-call (lambda (&rest values)

--- a/src/char.lisp
+++ b/src/char.lisp
@@ -334,8 +334,8 @@ character exists."
 except with Common Lisp's suggested changes.
 For the first 32 characters ('C0 controls'), the first
 'Commonly used alternative alias' is used -- note that this differs from SBCL, which uses abbreviations.")
-;; I hope being slightly different from SBCL doesn't bite me down the road.
-;; I'll figure out a good way to add the other 21701 names later.
+;; I hope  being slightly different from  SBCL doesn't bite me  down the
+;; road. I'll figure out a good way to add the other 21701 names later.
 
 (defun char-name (char)
   ;; For consistency, I'm using the SBCL convention of the Unicode

--- a/src/compiler/codegen.lisp
+++ b/src/compiler/codegen.lisp
@@ -1,4 +1,4 @@
-;;; compiler-codege.lisp --- Naive Javascript unparser
+;;; compiler/codegen.lisp --- Naive Javascript unparser
 
 ;; Copyright (C) 2013, 2014 David Vazquez
 
@@ -53,16 +53,13 @@
 
 (defvar *js-pretty-print* t)
 
-;;; Two seperate functions are needed for escaping strings:
-;;;  One for producing JavaScript string literals (which are singly or
-;;;   doubly quoted)
-;;;  And one for producing Lisp strings (which are only doubly quoted)
+;;; Two seperate  functions are  needed for  escaping strings: One  for producing  JavaScript string
+;;;  literals (which are singly or doubly quoted) And one for producing Lisp strings (which are only
+;;;  doubly quoted)
 ;;;
-;;; The same function would suffice for both, but for javascript string
-;;; literals it is neater to use either depending on the context, e.g:
-;;;  foo's => "foo's"
-;;;  "foo" => '"foo"'
-;;; which avoids having to escape quotes where possible
+;;; The same function would suffice for both, but for javascript string literals it is neater to use
+;;; either depending on the  context, e.g: foo's => "foo's" "foo" => '"foo"'  which avoids having to
+;;; escape quotes where possible
 (defun js-escape-string (string)
   (let ((index 0)
         (size (length string))
@@ -86,7 +83,7 @@
       ;; First, scan the string for single/double quotes
       (while (< index size)
         (let ((ch (char string index)))
-          (when (char= ch #\')
+          (when (char= ch #\apostrophe)
             (setq seen-single-quote t))
           (when (char= ch #\")
             (setq seen-double-quote t)))
@@ -103,9 +100,8 @@
 (defun js-format (fmt &rest args)
   (apply #'format *js-output* fmt args))
 
-;;; Check if STRING-DESIGNATOR is valid as a Javascript identifier. It
-;;; returns a couple of values. The identifier itself as a string and
-;;; a boolean value with the result of this check.
+;;; Check if STRING-DESIGNATOR is  valid as a Javascript identifier. It returns  a couple of values.
+;;; The identifier itself as a string and a boolean value with the result of this check.
 (defun valid-js-identifier (string-designator)
   (let ((string (typecase string-designator
                   (symbol (symbol-name string-designator))
@@ -124,8 +120,8 @@
 
 ;;; Expression generators
 ;;;
-;;; `js-expr' and the following auxiliary functions are the
-;;; responsible for generating Javascript expression.
+;;; `js-expr'  and   the  following   auxiliary  functions  are   the  responsible   for  generating
+;;; Javascript expression.
 
 (defun js-identifier (string-designator)
   (multiple-value-bind (string valid)
@@ -541,8 +537,8 @@
                  (js-expr object)
                  (js-end-stmt)))
            (object
-            ;; wrap ourselves within a pair of parens, in case JS EVAL
-            ;; interprets us as a block of code
+            ;; wrap ourselves within a  pair of parens, in case JS EVAL interprets  us as a block of
+            ;; code
             (js-object-initializer (cdr form) t)
             (js-end-stmt))
            (t

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1,26 +1,26 @@
 ;;; compiler.lisp ---
 
-;; JSCL is free software: you can redistribute it and/or
-;; modify it under the terms of the GNU General Public License as
-;; published by the Free Software Foundation, either version 3 of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with JSCL.  If not, see <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 ;;;; Compiler
 
 (/debug "loading compiler.lisp!")
 
-;;; Translate the Lisp code to Javascript. It will compile the special
-;;; forms. Some primitive functions are compiled as special forms
-;;; too. The respective real functions are defined in the target (see
-;;; the beginning of this file) as well as some primitive functions.
+;;; Translate the Lisp  code to Javascript. It will  compile the special
+;;; forms. Some primitive  functions are compiled as  special forms too.
+;;; The respective  real functions  are defined in  the target  (see the
+;;; beginning of this file) as well as some primitive functions.
 
 (define-js-macro selfcall (&body body)
   `(call (function () ,@body)))
@@ -47,12 +47,11 @@
   `(if ,expr ,(convert t) ,(convert nil)))
 
 
-;;; A Form can return a multiple values object calling VALUES, like
-;;; values(arg1, arg2, ...). It will work in any context, as well as
-;;; returning an individual object. However, if the special variable
-;;; `*multiple-value-p*' is NIL, is granted that only the primary
-;;; value will be used, so we can optimize to avoid the VALUES
-;;; function call.
+;;; A  Form can  return a  multiple values  object calling  VALUES, like
+;;; values(arg1, arg2,  ...). It will  work in  any context, as  well as
+;;; returning  an individual  object. However,  if the  special variable
+;;; `*multiple-value-p*' is NIL, is granted  that only the primary value
+;;; will be used, so we can optimize to avoid the VALUES function call.
 (defvar *multiple-value-p* nil)
 
 ;;; It is bound dinamically to the number of nested calls to
@@ -64,23 +63,23 @@
 ;;; Environment
 
 (def!struct binding
-  name
+    name
   type
   value
   declarations)
 
 (def!struct lexenv
-  variable
+    variable
   function
   block
   gotag)
 
 (defun lookup-in-lexenv (name lexenv namespace)
   (find name (ecase namespace
-                (variable (lexenv-variable lexenv))
-                (function (lexenv-function lexenv))
-                (block    (lexenv-block    lexenv))
-                (gotag    (lexenv-gotag    lexenv)))
+               (variable (lexenv-variable lexenv))
+               (function (lexenv-function lexenv))
+               (block    (lexenv-block    lexenv))
+               (gotag    (lexenv-gotag    lexenv)))
         :key #'binding-name))
 
 (defun push-to-lexenv (binding lexenv namespace)
@@ -172,7 +171,7 @@
 (defvar *fn-info* '())
 
 (def!struct fn-info
-  symbol
+    symbol
   defined
   called)
 
@@ -244,9 +243,9 @@
 
 (defun ll-keyword-arguments-canonical (ll)
   (flet ((canonicalize (keyarg)
-	   ;; Build a canonical keyword argument descriptor, filling
-	   ;; the optional fields. The result is a list of the form
-	   ;; ((keyword-name var) init-form svar).
+           ;; Build a canonical keyword argument descriptor, filling the
+           ;; optional  fields.  The  result  is  a  list  of  the  form
+           ;; ((keyword-name var) init-form svar).
            (let ((arg (ensure-list keyarg)))
              (cons (if (listp (car arg))
                        (car arg)
@@ -256,7 +255,7 @@
 
 (defun ll-keyword-arguments (ll)
   (mapcar (lambda (keyarg) (second (first keyarg)))
-	  (ll-keyword-arguments-canonical ll)))
+          (ll-keyword-arguments-canonical ll)))
 
 (defun ll-svars (lambda-list)
   (let ((args
@@ -303,17 +302,17 @@
                                         (convert t)))
                                 svars)))
          (switch (nargs)
-                 ,@(with-collect
-                    (dotimes (idx n-optional-arguments)
-                      (let ((arg (nth idx optional-arguments)))
-                        (collect `(case ,(+ idx n-required-arguments)))
-                        (collect `(= ,(translate-variable (car arg))
-                                     ,(convert (cadr arg))))
-                        (collect (when (third arg)
-                                   `(= ,(translate-variable (third arg))
-                                       ,(convert nil))))))
-                    (collect 'default)
-                    (collect '(break))))))))
+           ,@(with-collect
+              (dotimes (idx n-optional-arguments)
+                (let ((arg (nth idx optional-arguments)))
+                  (collect `(case ,(+ idx n-required-arguments)))
+                  (collect `(= ,(translate-variable (car arg))
+                               ,(convert (cadr arg))))
+                  (collect (when (third arg)
+                             `(= ,(translate-variable (third arg))
+                                 ,(convert nil))))))
+              (collect 'default)
+              (collect '(break))))))))
 
 (defun compile-lambda-rest (ll)
   (let ((n-required-arguments (length (ll-required-arguments ll)))
@@ -327,15 +326,15 @@
            (for ((= i (- (nargs) 1))
                  (>= i ,(+ n-required-arguments n-optional-arguments))
                  (post-- i))
-                (= ,js!rest (new (call-internal |Cons| (arg i) ,js!rest)))))))))
+             (= ,js!rest (new (call-internal |Cons| (arg i) ,js!rest)))))))))
 
 (defun compile-lambda-parse-keywords (ll)
   (let ((n-required-arguments
-	 (length (ll-required-arguments ll)))
-	(n-optional-arguments
-	 (length (ll-optional-arguments ll)))
-	(keyword-arguments
-	 (ll-keyword-arguments-canonical ll)))
+         (length (ll-required-arguments ll)))
+        (n-optional-arguments
+         (length (ll-optional-arguments ll)))
+        (keyword-arguments
+         (ll-keyword-arguments-canonical ll)))
     `(progn
        ;; Declare variables
        ,@(with-collect
@@ -351,40 +350,40 @@
 
        ;; Parse keywords
        ,(flet ((parse-keyword (keyarg)
-                (destructuring-bind ((keyword-name var) &optional initform svar) keyarg
-                  ;; ((keyword-name var) init-form svar)
-                  `(progn
-                     (for ((= i ,(+ n-required-arguments n-optional-arguments))
-                           (< i (nargs))
-                           (+= i 2))
-                          ;; ....
-                          (if (=== (arg i) ,(convert keyword-name))
-                              (progn
-                                (= ,(translate-variable var) (arg (+ i 1)))
-                                ,(when svar `(= ,(translate-variable svar)
-                                                ,(convert t)))
-                                (break))))
-                     (if (== i (nargs))
-                         (= ,(translate-variable var) ,(convert initform)))))))
-         (when keyword-arguments
-           `(progn
-              (var i)
-              ,@(mapcar #'parse-keyword keyword-arguments))))
+                              (destructuring-bind ((keyword-name var) &optional initform svar) keyarg
+                                ;; ((keyword-name var) init-form svar)
+                                `(progn
+                                   (for ((= i ,(+ n-required-arguments n-optional-arguments))
+                                         (< i (nargs))
+                                         (+= i 2))
+                                     ;; ....
+                                     (if (=== (arg i) ,(convert keyword-name))
+                                         (progn
+                                           (= ,(translate-variable var) (arg (+ i 1)))
+                                           ,(when svar `(= ,(translate-variable svar)
+                                                           ,(convert t)))
+                                           (break))))
+                                   (if (== i (nargs))
+                                       (= ,(translate-variable var) ,(convert initform)))))))
+              (when keyword-arguments
+                `(progn
+                   (var i)
+                   ,@(mapcar #'parse-keyword keyword-arguments))))
 
        ;; Check for unknown keywords
        ,(when keyword-arguments
-         `(progn
-            (var (start ,(+ n-required-arguments n-optional-arguments)))
-            (if (== (% (- (nargs) start) 2) 1)
-                (throw "Odd number of keyword arguments."))
-            (for ((= i start) (< i (nargs)) (+= i 2))
-                 (if (and ,@(mapcar (lambda (keyword-argument)
-                                 (destructuring-bind ((keyword-name var) &optional initform svar)
-                                     keyword-argument
-                                   (declare (ignore var initform svar))
-                                   `(!== (arg i) ,(convert keyword-name))))
-                               keyword-arguments))
-                     (throw (+ "Unknown keyword argument " (property (arg i) "name"))))))))))
+              `(progn
+                 (var (start ,(+ n-required-arguments n-optional-arguments)))
+                 (if (== (% (- (nargs) start) 2) 1)
+                     (throw "Odd number of keyword arguments."))
+                 (for ((= i start) (< i (nargs)) (+= i 2))
+                   (if (and ,@(mapcar (lambda (keyword-argument)
+                                        (destructuring-bind ((keyword-name var) &optional initform svar)
+                                            keyword-argument
+                                          (declare (ignore var initform svar))
+                                          `(!== (arg i) ,(convert keyword-name))))
+                                      keyword-arguments))
+                       (throw (+ "Unknown keyword argument " (property (arg i) "name"))))))))))
 
 (defun parse-lambda-list (ll)
   (values (ll-required-arguments ll)
@@ -424,7 +423,7 @@
 ;;; NAME is given, it should be a constant string and it will become
 ;;; the name of the function. If BLOCK is non-NIL, a named block is
 ;;; created around the body. NOTE: No block (even anonymous) is
-;;; created if BLOCk is NIL.
+;;; created if BLOCK is NIL.
 (defun compile-lambda (ll body &key name block)
   (multiple-value-bind (required-arguments
                         optional-arguments
@@ -444,21 +443,21 @@
                                     (ll-svars ll)))))
 
         (lambda-name/docstring-wrapper name documentation
-         `(function (|values| ,@(mapcar (lambda (x)
-                                          (translate-variable x))
-                                        (append required-arguments optional-arguments)))
-                     ;; Check number of arguments
-                    ,(lambda-check-argument-count n-required-arguments
-                                                  n-optional-arguments
-                                                  (or rest-argument keyword-arguments))
-                    ,(compile-lambda-optional ll)
-                    ,(compile-lambda-rest ll)
-                    ,(compile-lambda-parse-keywords ll)
-                    ,(bind-this)
-                    ,(let ((*multiple-value-p* t))
-                          (if block
-                              (convert-block `((block ,block ,@body)) t)
-                              (convert-block body t)))))))))
+                                       `(function (|values| ,@(mapcar (lambda (x)
+                                                                        (translate-variable x))
+                                                                      (append required-arguments optional-arguments)))
+                                                  ;; Check number of arguments
+                                                  ,(lambda-check-argument-count n-required-arguments
+                                                                                n-optional-arguments
+                                                                                (or rest-argument keyword-arguments))
+                                                  ,(compile-lambda-optional ll)
+                                                  ,(compile-lambda-rest ll)
+                                                  ,(compile-lambda-parse-keywords ll)
+                                                  ,(bind-this)
+                                                  ,(let ((*multiple-value-p* t))
+                                                        (if block
+                                                            (convert-block `((block ,block ,@body)) t)
+                                                            (convert-block body t)))))))))
 
 
 (defun setq-pair (var val)
@@ -467,9 +466,9 @@
   (let ((b (lookup-in-lexenv var *environment* 'variable)))
     (cond
       ((and b
-	    (eq (binding-type b) 'variable)
-	    (not (member 'special (binding-declarations b)))
-	    (not (member 'constant (binding-declarations b))))
+            (eq (binding-type b) 'variable)
+            (not (member 'special (binding-declarations b)))
+            (not (member 'constant (binding-declarations b))))
        `(= ,(binding-value b) ,(convert val)))
       ((and b (eq (binding-type b) 'macro))
        (convert `(setf ,var ,val)))
@@ -601,8 +600,8 @@
     ((symbolp x)
      (let ((b (lookup-in-lexenv x *environment* 'function)))
        (if b
-	   (binding-value b)
-	   (convert `(symbol-function ',x)))))))
+           (binding-value b)
+           (convert `(symbol-function ',x)))))))
 
 (defun make-function-binding (fname)
   (make-binding :name fname :type 'function :value (gvarname fname)))
@@ -626,12 +625,12 @@
                          *environment*
                          'function)))
     `(call (function ,(mapcar #'translate-function fnames)
-                ,(convert-block body t))
+                     ,(convert-block body t))
            ,@cfuncs)))
 
 (define-compilation labels (definitions &rest body)
   (let* ((fnames (mapcar #'car definitions))
-	 (*environment*
+         (*environment*
           (extend-lexenv (mapcar #'make-function-binding fnames)
                          *environment*
                          'function)))
@@ -893,15 +892,15 @@
                (while true
                  (try
                   (switch ,branch
-                          ,@(with-collect
-                             (collect `(case ,initag))
-                             (dolist (form (cdr body))
-                               (if (go-tag-p form)
-                                   (let ((b (lookup-in-lexenv form *environment* 'gotag)))
-                                     (collect `(case ,(second (binding-value b)))))
-                                   (collect (convert form)))))
-                          default
-                          (break tbloop)))
+                    ,@(with-collect
+                       (collect `(case ,initag))
+                       (dolist (form (cdr body))
+                         (if (go-tag-p form)
+                             (let ((b (lookup-in-lexenv form *environment* 'gotag)))
+                               (collect `(case ,(second (binding-value b)))))
+                             (collect (convert form)))))
+                    default
+                    (break tbloop)))
                  (catch (jump)
                    (if (and (instanceof jump (internal |TagNLX|)) (== (get jump "id") ,tbidx))
                        (= ,branch (get jump "label"))
@@ -991,7 +990,13 @@
                 (collect-fargs v)
                 (collect-prelude `(var (,v ,(convert x))))
                 (collect-prelude `(if (!= (typeof ,v) "number")
-                                      (throw "Not a number!"))))))
+                                      (throw (new (call |Error| (+ "" (typeof ,v)
+                                                                   " is not a number: " ,v " "
+                                                                   ,(princ-to-string (convert x)) " in "
+                                                                   ,(princ-to-string function)
+                                                                   ,@(mapcar (lambda (s)
+                                                                               (concatenate 'string " "
+                                                                                            (princ-to-string s))) args))))))))))
         `(selfcall
           (progn ,@prelude)
           ,(funcall function fargs))))))
@@ -1006,7 +1011,7 @@
   (if (null numbers)
       0
       (variable-arity numbers
-        `(+ ,@numbers))))
+                      `(+ ,@numbers))))
 
 (define-raw-builtin - (x &rest others)
   (let ((args (cons x others)))
@@ -1020,10 +1025,10 @@
 (define-raw-builtin / (x &rest others)
   (let ((args (cons x others)))
     (variable-arity args
-      (if (null others)
-          `(call-internal |handled_division| 1 ,(car args))
-          (reduce (lambda (x y) `(call-internal |handled_division| ,x ,y))
-                  args)))))
+                    (if (null others)
+                        `(call-internal |handled_division| 1 ,(car args))
+                        (reduce (lambda (x y) `(call-internal |handled_division| ,x ,y))
+                                args)))))
 
 (define-builtin mod (x y)
   `(selfcall
@@ -1046,7 +1051,7 @@
   `(define-raw-builtin ,op (x &rest args)
      (let ((args (cons x args)))
        (variable-arity args
-         (convert-to-bool (comparison-conjuntion args ',sym))))))
+                       (convert-to-bool (comparison-conjuntion args ',sym))))))
 
 (define-builtin-comparison > >)
 (define-builtin-comparison < <)
@@ -1087,15 +1092,15 @@
 
 (define-builtin rplaca (x new)
   `(selfcall
-     (var (tmp ,x))
-     (= (get tmp "car") ,new)
-     (return tmp)))
+    (var (tmp ,x))
+    (= (get tmp "car") ,new)
+    (return tmp)))
 
 (define-builtin rplacd (x new)
   `(selfcall
-     (var (tmp ,x))
-     (= (get tmp "cdr") ,new)
-     (return tmp)))
+    (var (tmp ,x))
+    (= (get tmp "cdr") ,new)
+    (return tmp)))
 
 (define-builtin symbolp (x)
   (convert-to-bool `(instanceof ,x (internal |Symbol|))))
@@ -1165,7 +1170,7 @@
                       f
                       (get f "fvalue"))
                   ,@(cons (if *multiple-value-p* '|values| '(internal |pv|))
-			  (mapcar #'convert args))))))
+                          (mapcar #'convert args))))))
 
 (define-raw-builtin apply (func &rest args)
   (if (null args)
@@ -1173,20 +1178,20 @@
       (let ((args (butlast args))
             (last (car (last args))))
         `(selfcall
-	  (var (f ,(convert func)))
-	  (var (args ,(list-to-vector
-		       (cons (if *multiple-value-p* '|values| '(internal |pv|))
-			     (mapcar #'convert args)))))
-	  (var (tail ,(convert last)))
-	  (while (!= tail ,(convert nil))
-	    (method-call args "push" (get tail "car"))
-	    (= tail (get tail "cdr")))
-	  (return (method-call (if (=== (typeof f) "function")
-				   f
-				   (get f "fvalue"))
-			       "apply"
-			       this
-			       args))))))
+          (var (f ,(convert func)))
+          (var (args ,(list-to-vector
+                       (cons (if *multiple-value-p* '|values| '(internal |pv|))
+                             (mapcar #'convert args)))))
+          (var (tail ,(convert last)))
+          (while (!= tail ,(convert nil))
+            (method-call args "push" (get tail "car"))
+            (= tail (get tail "cdr")))
+          (return (method-call (if (=== (typeof f) "function")
+                                   f
+                                   (get f "fvalue"))
+                               "apply"
+                               this
+                               args))))))
 
 (define-builtin js-eval (string)
   (if *multiple-value-p*
@@ -1233,7 +1238,7 @@
 (define-builtin storage-vector-ref (vector n)
   `(selfcall
     (var (x (property ,vector ,n)))
-    (if (=== x undefined) (throw "Out of range."))
+    (if (=== x undefined) (throw (new (call |Error| ,(concatenate 'string "AREF out of range for vector " (string vector))))))
     (return x)))
 
 (define-builtin storage-vector-set (vector n value)
@@ -1241,16 +1246,16 @@
     (var (x ,vector))
     (var (i ,n))
     (if (or (< i 0) (>= i (get x "length")))
-        (throw "Out of range."))
+        (throw (new (call |Error| ,(concatenate 'string "SETF AREF out of range for vector " (string vector))))))
     (return (= (property x i) ,value))))
 
 (define-builtin concatenate-storage-vector (sv1 sv2)
   `(selfcall
-     (var (sv1 ,sv1))
-     (var (r (method-call sv1 "concat" ,sv2)))
-     (= (get r "type") (get sv1 "type"))
-     (= (get r "stringp") (get sv1 "stringp"))
-     (return r)))
+    (var (sv1 ,sv1))
+    (var (r (method-call sv1 "concat" ,sv2)))
+    (= (get r "type") (get sv1 "type"))
+    (= (get r "stringp") (get sv1 "stringp"))
+    (return r)))
 
 (define-builtin get-internal-real-time ()
   `(method-call (new (call |Date|)) "getTime"))
@@ -1336,7 +1341,7 @@
          key)
     (for-in (key o)
             (call g ,(if *multiple-value-p* '|values| '(internal |pv|))
-		  (property o key)))
+                  (property o key)))
     (return ,(convert nil))))
 
 (define-compilation %js-vref (var)
@@ -1455,7 +1460,7 @@
 
 (defun compile-funcall (function args)
   (let* ((arglist (cons (if *multiple-value-p* '|values| '(internal |pv|))
-			(mapcar #'convert args))))
+                        (mapcar #'convert args))))
     (unless (or (symbolp function)
                 (and (consp function)
                      (member (car function) '(lambda oget))))
@@ -1473,14 +1478,14 @@
        `(call ,(convert `(function ,function)) ,@arglist))
       ((and (consp function) (eq (car function) 'oget))
        `(call-internal |js_to_lisp|
-              (call ,(reduce (lambda (obj p)
-                               `(property ,obj (call-internal |xstring| ,p)))
-                             (mapcar #'convert (cdr function)))
-                    ,@(mapcar (lambda (s)
-                                `(call-internal |lisp_to_js| ,(convert s)))
-                              args))))
+                       (call ,(reduce (lambda (obj p)
+                                        `(property ,obj (call-internal |xstring| ,p)))
+                                      (mapcar #'convert (cdr function)))
+                             ,@(mapcar (lambda (s)
+                                         `(call-internal |lisp_to_js| ,(convert s)))
+                                       args))))
       (t
-       (error "Bad function descriptor")))))
+       (error "Bad function designator `~S'" function)))))
 
 (defun convert-block (sexps &optional return-last-p decls-allowed-p)
   (multiple-value-bind (sexps decls)

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -32,31 +32,31 @@ var nil;
 var jscl = {};
 
 if (typeof module !== 'undefined')
-  module.exports = jscl;
+    module.exports = jscl;
 else
-  window.jscl = jscl;
+    window.jscl = jscl;
 
 
 var internals = jscl.internals = {};
 
 internals.globalEval = function(code){
-  var geval = eval;             // Just an indirect eval
-  var fn = geval('(function(values, internals){ "use strict"; ' + code + '; })');
-  return fn(internals.mv, internals);
+    var geval = eval;             // Just an indirect eval
+    var fn = geval('(function(values, internals){ "use strict"; ' + code + '; })');
+    return fn(internals.mv, internals);
 };
 
 internals.pv = function(x) {
-  return x==undefined? nil: x;
+    return x==undefined? nil: x;
 };
 
 internals.mv = function(){
-  var r = [].slice.call(arguments);
-  r['multiple-value'] = true;
-  return r;
+    var r = [].slice.call(arguments);
+    r['multiple-value'] = true;
+    return r;
 };
 
 internals.forcemv = function(x) {
-  return typeof x == 'object' && 'multiple-value' in x? x: internals.mv(x);
+    return typeof x == 'object' && 'multiple-value' in x? x: internals.mv(x);
 };
 
 // NOTE: Define VALUES to be MV for toplevel forms. It is because
@@ -66,58 +66,58 @@ internals.forcemv = function(x) {
 var values = internals.mv;
 
 internals.checkArgsAtLeast = function(args, n){
-  if (args < n) throw 'too few arguments';
+    if (args < n) throw new Error('too few arguments; needed at least ' + n + ' but got only ' + args);
 };
 
 internals.checkArgsAtMost = function(args, n){
-  if (args > n) throw 'too many arguments';
+    if (args > n) throw new Error ('too many arguments; needed at most ' + n + ' but got ' + args);
 };
 
 internals.checkArgs = function(args, n){
-  internals.checkArgsAtLeast(args, n);
-  internals.checkArgsAtMost(args, n);
+    internals.checkArgsAtLeast(args, n);
+    internals.checkArgsAtMost(args, n);
 };
 
 
 // Lists
 
 internals.Cons = function (car, cdr) {
-  this.car = car;
-  this.cdr = cdr;
+    this.car = car;
+    this.cdr = cdr;
 };
 
 internals.car = function(x){
-  if (x === nil)
-    return nil;
-  else if (x instanceof internals.Cons)
-    return x.car;
-  else {
-    console.log(x);
-    throw new Error('CAR called on non-list argument');
-  }
+    if (x === nil)
+        return nil;
+    else if (x instanceof internals.Cons)
+        return x.car;
+    else {
+        console.log(x);
+        throw new Error('CAR called on non-list argument ' + x);
+    }
 };
 
 internals.cdr = function(x){
-  if (x === nil)
-    return nil;
-  else if (x instanceof internals.Cons)
-    return x.cdr;
-  else
-    throw new Error('CDR called on non-list argument');
+    if (x === nil)
+        return nil;
+    else if (x instanceof internals.Cons)
+        return x.cdr;
+    else
+        throw new Error('CDR called on non-list argument ' + x);
 };
 
 // Improper list constructor (like LIST*)
 internals.QIList = function(){
-  if (arguments.length == 1)
-    return arguments[0];
-  else {
-    var i = arguments.length-1;
-    var r = arguments[i--];
-    for (; i>=0; i--){
-      r = new internals.Cons(arguments[i], r);
+    if (arguments.length == 1)
+        return arguments[0];
+    else {
+        var i = arguments.length-1;
+        var r = arguments[i--];
+        for (; i>=0; i--){
+            r = new internals.Cons(arguments[i], r);
+        }
+        return r;
     }
-    return r;
-  }
 };
 
 
@@ -126,8 +126,8 @@ internals.QIList = function(){
 // Arithmetic
 
 internals.handled_division = function (x, y) {
-  if (y == 0) throw "Division by zero";
-  return x/y;
+    if (y == 0) throw new Error("Division (of " + x + ") by zero");
+    return x/y;
 };
 
 
@@ -136,121 +136,121 @@ internals.handled_division = function (x, y) {
 
 // Return a new Array of strings, each either length-1, or length-2 (a UTF-16 surrogate pair).
 function codepoints (string) {
-  return string.split(/(?![\udc00-\udfff])/);
+    return string.split(/(?![\udc00-\udfff])/);
 };
 
 // Create and return a lisp string for the Javascript string STRING.
 internals.make_lisp_string = function (string){
-  var array = codepoints(string);
-  array.stringp = 1;
-  return array;
+    var array = codepoints(string);
+    array.stringp = 1;
+    return array;
 };
 
 internals.char_to_codepoint = function(ch) {
-  if (ch.length == 1) {
-    return ch.charCodeAt(0);
-  } else {
-    var xh = ch.charCodeAt(0) - 0xD800;
-    var xl = ch.charCodeAt(1) - 0xDC00;
-    return 0x10000 + (xh << 10) + (xl);
-  }
+    if (ch.length == 1) {
+        return ch.charCodeAt(0);
+    } else {
+        var xh = ch.charCodeAt(0) - 0xD800;
+        var xl = ch.charCodeAt(1) - 0xDC00;
+        return 0x10000 + (xh << 10) + (xl);
+    }
 };
 
 internals.char_from_codepoint = function(x) {
-  if (x <= 0xFFFF) {
-    return String.fromCharCode(x);
-  } else {
-    x -= 0x10000;
-    var xh = x >> 10;
-    var xl = x & 0x3FF;
-    return String.fromCharCode(0xD800 + xh) + String.fromCharCode(0xDC00 + xl);
-  }
+    if (x <= 0xFFFF) {
+        return String.fromCharCode(x);
+    } else {
+        x -= 0x10000;
+        var xh = x >> 10;
+        var xl = x & 0x3FF;
+        return String.fromCharCode(0xD800 + xh) + String.fromCharCode(0xDC00 + xl);
+    }
 };
 
 // if a char (JS string) has the same number of codepoints after .toUpperCase(), return that, else the original.
 internals.safe_char_upcase = function(x) {
-  var xu = x.toUpperCase();
-  if (codepoints(xu).length == 1) {
-    return xu;
-  } else {
-    return x;
-  }
+    var xu = x.toUpperCase();
+    if (codepoints(xu).length == 1) {
+        return xu;
+    } else {
+        return x;
+    }
 };
 internals.safe_char_downcase = function(x) {
-  var xl = x.toLowerCase();
-  if (codepoints(xl).length == 1) {
-    return xl;
-  } else {
-    return x;
-  }
+    var xl = x.toLowerCase();
+    if (codepoints(xl).length == 1) {
+        return xl;
+    } else {
+        return x;
+    }
 };
 
 internals.xstring = function(x){
-  return x.join('');
+    return x.join('');
 };
 
 
 internals.lisp_to_js = function (x) {
-  if (typeof x == 'object' && 'length' in x && x.stringp == 1)
-    return internals.xstring(x);
-  else if (x === t)
-    return true;
-  else if (x === nil)
-    return false;
-  else if (typeof x == 'function'){
-    // Trampoline calling the Lisp function
-    return (function(){
-      var args = Array.prototype.slice.call(arguments);
-      for (var i in args)
-        args[i] = internals.js_to_lisp(args[i]);
-      return internals.lisp_to_js(x.apply(this, [internals.pv].concat(args)));
-    });
-  }
-  else return x;
+    if (typeof x == 'object' && 'length' in x && x.stringp == 1)
+        return internals.xstring(x);
+    else if (x === t)
+        return true;
+    else if (x === nil)
+        return false;
+    else if (typeof x == 'function'){
+        // Trampoline calling the Lisp function
+        return (function(){
+            var args = Array.prototype.slice.call(arguments);
+            for (var i in args)
+                args[i] = internals.js_to_lisp(args[i]);
+            return internals.lisp_to_js(x.apply(this, [internals.pv].concat(args)));
+        });
+    }
+    else return x;
 };
 
 internals.js_to_lisp = function (x) {
-  if (typeof x == 'string')
-    return internals.make_lisp_string(x);
-  else if (x === true)
-    return t;
-  else if (x === false)
-    return nil;
-  else if (typeof x == 'function'){
-    // Trampoline calling the JS function
-    return (function(values){
-      var args = Array.prototype.slice.call(arguments, 1);
-      for (var i in args)
-        args[i] = internals.lisp_to_js(args[i]);
-      return values(internals.js_to_lisp(x.apply(this, args)));
-    });
-  } else return x;
+    if (typeof x == 'string')
+        return internals.make_lisp_string(x);
+    else if (x === true)
+        return t;
+    else if (x === false)
+        return nil;
+    else if (typeof x == 'function'){
+        // Trampoline calling the JS function
+        return (function(values){
+            var args = Array.prototype.slice.call(arguments, 1);
+            for (var i in args)
+                args[i] = internals.lisp_to_js(args[i]);
+            return values(internals.js_to_lisp(x.apply(this, args)));
+        });
+    } else return x;
 };
 
 
 // Non-local exits
 
 internals.BlockNLX = function (id, values, name){
-  this.id = id;
-  this.values = values;
-  this.name = name;
+    this.id = id;
+    this.values = values;
+    this.name = name;
 };
 
 internals.CatchNLX = function (id, values){
-  this.id = id;
-  this.values = values;
+    this.id = id;
+    this.values = values;
 };
 
 internals.TagNLX = function (id, label){
-  this.id = id;
-  this.label = label;
+    this.id = id;
+    this.label = label;
 };
 
 internals.isNLX = function(x){
-  var i = internals;
-  return x instanceof i.BlockNLX
-    ||   x instanceof i.CatchNLX
-    ||   x instanceof i.TagNLX;
+    var i = internals;
+    return x instanceof i.BlockNLX
+        ||   x instanceof i.CatchNLX
+        ||   x instanceof i.TagNLX;
 };
 
 
@@ -259,107 +259,110 @@ internals.isNLX = function(x){
 var packages = jscl.packages = {};
 
 packages.JSCL = {
-  packageName: 'JSCL',
-  symbols: {},
-  exports: {},
-  use: nil
+    packageName: 'JSCL',
+    symbols: {},
+    exports: {},
+    use: nil
 };
 
 packages.CL = {
-  packageName: 'CL',
-  symbols: {},
-  exports: {},
-  use: nil
+    packageName: 'CL',
+    symbols: {},
+    exports: {},
+    use: nil
 };
 
 packages['COMMON-LISP'] = packages.CL;
 
 packages.KEYWORD = {
-  packageName: 'KEYWORD',
-  symbols: {},
-  exports: {},
-  use: nil
+    packageName: 'KEYWORD',
+    symbols: {},
+    exports: {},
+    use: nil
 };
 
 jscl.CL = packages.CL.exports;
 
 function unboundFunction () {
-  throw new Error("Function '" + this.name + "' undefined");
+    throw new Error("Function '" + this.name + "' undefined");
 }
 
 internals.Symbol = function(name, package_name){
-  this.name = name;
-  this.package = package_name;
-  this.value = undefined;
-  this.fvalue = unboundFunction;
+    this.name = name;
+    this.package = package_name;
+    this.value = undefined;
+    this.fvalue = unboundFunction;
 };
 
 internals.symbolValue = function (symbol){
-  var value = symbol.value;
-  if (value === undefined){
-    throw new Error("Variable " + symbol.name + " is unbound.");
-  } else {
-    return value;
-  }
+    if (symbol === undefined) {
+        throw new Error("Trying to take the value of «undefined» as a symbol");
+    }
+    var value = symbol.value;
+    if (value === undefined){
+        throw new Error("Variable " + ((symbol !== undefined) ? symbol.name || "(unnamed symbol)" : "(undefined symbol)") + " is unbound.");
+    } else {
+        return value;
+    }
 };
 
 internals.symbolFunction = function (symbol){
-  var fn = symbol.fvalue;
-  if (fn === unboundFunction)
-    symbol.fvalue();
-  return fn;
+    var fn = symbol.fvalue;
+    if (fn === unboundFunction)
+        symbol.fvalue();
+    return fn;
 };
 
 
 internals.bindSpecialBindings = function (symbols, values, callback){
-  try {
-    symbols.forEach(function(s, i){
-      s.stack = s.stack || [];
-      s.stack.push(s.value);
-      s.value = values[i];
-    });
-    return callback();
-  } finally {
-    symbols.forEach(function(s, i){
-      s.value = s.stack.pop();
-    });
-  }
+    try {
+        symbols.forEach(function(s, i){
+            s.stack = s.stack || [];
+            s.stack.push(s.value);
+            s.value = values[i];
+        });
+        return callback();
+    } finally {
+        symbols.forEach(function(s, i){
+            s.value = s.stack.pop();
+        });
+    }
 };
 
 internals.intern = function (name, package_name){
-  package_name = package_name || "JSCL";
-  var lisp_package = packages[package_name];
-  if (!lisp_package)
-    throw "No package " + package_name;
+    package_name = package_name || "JSCL";
+    var lisp_package = packages[package_name];
+    if (!lisp_package)
+        throw new Error ("No package " + package_name);
 
-  var symbol = lisp_package.symbols[name];
-  if (!symbol)
-    symbol = lisp_package.symbols[name] = new internals.Symbol(name, lisp_package);
+    var symbol = lisp_package.symbols[name];
+    if (!symbol)
+        symbol = lisp_package.symbols[name] = new internals.Symbol(name, lisp_package);
 
-  // Auto-export symbol if it is the KEYWORD package.
-  if (lisp_package === packages.KEYWORD)
-    lisp_package.exports[name] = symbol;
+    // Auto-export symbol if it is the KEYWORD package.
+    if (lisp_package === packages.KEYWORD)
+        lisp_package.exports[name] = symbol;
 
-  return symbol;
+    return symbol;
 };
 
 /* execute all script tags with type of x-common-lisp */
 var eval_in_lisp;               // set in FFI.lisp
 if (typeof window !== "undefined"){
-  window.onload = (function () {
-	var scripts = document.scripts;
-	for (var i = 0; i < scripts.length; ++i) {
-	  var script = scripts[i];
-	  /* TODO: what about errors? */
-	  if (script.type == "text/x-common-lisp") {
-		eval_in_lisp(script.text);
-	  }
-	}
-  });
+    window.onload = (function () {
+        var scripts = document.scripts;
+        for (var i = 0; i < scripts.length; ++i) {
+            var script = scripts[i];
+            /* TODO: what about errors? */
+            if (script.type == "text/x-common-lisp") {
+                eval_in_lisp(script.text);
+            }
+        }
+    });
 }
 
 // Node Readline
 if (typeof module !== 'undefined' &&
     typeof global !== 'undefined' &&
     typeof phantom === 'undefined')
-  global.readline = require('readline');
+    global.readline = require('readline');

--- a/src/print.lisp
+++ b/src/print.lisp
@@ -1,17 +1,17 @@
 ;;; print.lisp ---
 
-;; JSCL is free software: you can redistribute it and/or
-;; modify it under the terms of the GNU General Public License as
-;; published by the Free Software Foundation, either version 3 of the
-;; License, or (at your option) any later version.
+;; JSCL is free software: you can redistribute it and/or modify it under
+;; the terms of the GNU General  Public License as published by the Free
+;; Software Foundation,  either version  3 of the  License, or  (at your
+;; option) any later version.
 ;;
-;; JSCL is distributed in the hope that it will be useful, but
-;; WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;; General Public License for more details.
+;; JSCL is distributed  in the hope that it will  be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
 ;;
-;; You should have received a copy of the GNU General Public License
-;; along with JSCL.  If not, see <http://www.gnu.org/licenses/>.
+;; You should  have received a  copy of  the GNU General  Public License
+;; along with JSCL. If not, see <http://www.gnu.org/licenses/>.
 
 (/debug "loading print.lisp!")
 
@@ -25,15 +25,15 @@
       (let ((ch (char string index)))
         (when (or (char= ch #\") (char= ch #\\))
           (setq output (concat output "\\")))
-        (when (or (char= ch #\newline))
+        (when (or (char= ch #\newline))   	; wait, what? \n in Lisp? No… *BRFP TODO
           (setq output (concat output "\\"))
           (setq ch #\n))
         (setq output (concat output (string ch))))
       (incf index))
     (concat "\"" output "\"")))
 
-;;; Return T if the string S contains characters which need to be
-;;; escaped to print the symbol name, NIL otherwise.
+;;; Return T if the string S contains characters which  need to be escaped to print the symbol name,
+;;; NIL otherwise.
 (defun escape-symbol-name-p (s)
   (let ((dots-only t))
     (dotimes (i (length s))
@@ -47,12 +47,10 @@
           (return-from escape-symbol-name-p t))))
     dots-only))
 
-;;; Return T if the specified string can be read as a number
-;;; In case such a string is the name of a symbol then escaping
-;;; is required when printing to ensure correct reading.
+;;; Return T if the  specified string can be read as  a number In case such a string  is the name of
+;;; a symbol then escaping is required when printing to ensure correct reading.
 (defun potential-number-p (string)
-  ;; The four rules for being a potential number are described in
-  ;; 2.3.1.1 Potential Numbers as Token
+  ;; The four rules for being a potential number are described in 2.3.1.1 Potential Numbers as Token
   ;;
   ;; First Rule
   (dotimes (i (length string))
@@ -68,8 +66,8 @@
         ((alpha-char-p char)
          (when (and (< i (1- (length string)))
                     (alpha-char-p (char string (1+ i))))
-           ;; fail: adjacent letters are not number marker, or
-           ;; there is a decimal point in the string.
+           ;; fail:  adjacent  letters are  not  number  marker, or  there  is  a decimal  point  in
+           ;; the string.
            (return-from potential-number-p)))
         (t
          ;; fail: there is a non-allowed character
@@ -120,14 +118,12 @@
 ;; they're found multiple times by assining them an id starting from
 ;; 1.
 ;;
-;; After the tracking has been completed the printing phase can begin:
-;; if an object has an id > 0 then #<n>= is prefixed and the id is
-;; changed to negative. If an object has an id < 0 then #<-n># is
-;; printed instead of the object.
+;; After the  tracking has been completed  the printing phase  can begin: if  an object has an  id >
+;; 0 then  #<n>= is prefixed  and the id is  changed to negative.  If an object  has an id <  0 then
+;; #<-n># is printed instead of the object.
 ;;
-;; The processing is O(n^2) with n = number of tracked
-;; objects. Hopefully it will become good enough when the new compiler
-;; is available.
+;; The processing is O(n^2) with n = number of tracked objects. Hopefully it will become good enough
+;; when the new compiler is available.
 (defun scan-multiple-referenced-objects (form)
   (let ((known-objects (make-array 0 :adjustable t :fill-pointer 0))
         (object-ids    (make-array 0 :adjustable t :fill-pointer 0)))
@@ -164,10 +160,10 @@
 (defun write-integer (value stream)
   (write-string (integer-to-string value) stream))
 
-;;; This version of format supports only ~A for strings and ~D for
-;;; integers. It is used to avoid circularities. Indeed, it just
-;;; ouputs to streams.
 (defun simple-format (stream fmt &rest args)
+  "This  version of  format  supports only  ~A for  strings  and ~D  for
+integers. It  is used  to avoid circularities.  Indeed, it  just outputs
+to streams."
   (do ((i 0 (1+ i)))
       ((= i (length fmt)))
     (let ((char (char fmt i)))
@@ -202,13 +198,12 @@
     (symbol
      (let ((name (symbol-name form))
            (package (symbol-package form)))
-       ;; Check if the symbol is accesible from the current package. It
-       ;; is true even if the symbol's home package is not the current
-       ;; package, because it could be inherited.
+       ;; Check if the symbol is accesible from the current package. It is true even if the symbol's
+       ;; home package is not the current package, because it could be inherited.
        (if (eq form (find-symbol (symbol-name form)))
            (write-string (escape-token (symbol-name form)) stream)
-           ;; Symbol is not accesible from *PACKAGE*, so let us prefix
-           ;; the symbol with the optional package or uninterned mark.
+           ;; Symbol is not accesible from *PACKAGE*, so  let us prefix the symbol with the optional
+           ;; package or uninterned mark.
            (progn
              (cond
                ((null package) (write-char #\# stream))
@@ -254,8 +249,7 @@
      (unless (null form)
        (write-aux (car form) stream known-objects object-ids)
        (do ((tail (cdr form) (cdr tail)))
-           ;; Stop on symbol OR if the object is already known when we
-           ;; accept circular printing.
+           ;; Stop on symbol OR if the object is already known when we accept circular printing.
            ((or (atom tail)
                 (and *print-circle*
                      (let* ((ix (or (position tail known-objects) 0))
@@ -327,12 +321,12 @@
   (defun terpri ()
     (write-char #\newline)
     (values))
-  
+
   (defun write-line (x)
     (write-string x)
     (terpri)
     x)
-  
+
   (defun print (x)
     (prog1 (prin1 x)
       (terpri))))
@@ -361,7 +355,7 @@
               (cond
                 ((char= next #\~)
                  (concatf res "~"))
-                ((or (char= next #\&) 
+                ((or (char= next #\&)
                      (char= next #\%))
                  (concatf res (string #\newline)))
                 ((char= next #\*)

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -48,13 +48,11 @@
 ;; (e.g. #1# while reading elements of "#1=(#1# #1# #1#)")
 (defvar *future-value* (make-symbol "future"))
 
-;; A unique value used to mark temporary values that will
-;; be replaced when fixups are run.
+;; A unique value used to mark temporary values that will be replaced when fixups are run.
 (defvar *fixup-value* (make-symbol "fixup"))
 
-;; Fixup locations keeps a list of conses where the CAR
-;; is a callable to be called with the value of the object
-;; associated to label stored in CDR once reading is completed
+;; Fixup locations keeps a list of conses where the CAR is a callable to be called with the value of
+;; the object associated to label stored in CDR once reading is completed
 (defvar *fixup-locations* nil)
 
 (defun fixup-backrefs ()
@@ -67,9 +65,8 @@
           (error "Internal error in fixup-backrefs: object #~S# not found"
                  (cdr fixup))))))
 
-;; A function that will need to return a fixup callback
-;; for the object that is being read. The returned callback will
-;; be called with the result of reading.
+;; A  function that  will  need to  return a  fixup  callback for  the  object that  is being  read.
+;; The returned callback will be called with the result of reading.
 (defvar *make-fixup-function*
   (lambda ()
     (error "Internal error in fixup creation during read")))
@@ -210,10 +207,9 @@
     (keyword
      (and (find expression *features*) t))
     (list
-     ;; Macrocharacters for conditional reading #+ and #- bind the
-     ;; current package to KEYWORD so features are correctly
-     ;; interned. For this reason, AND, OR and NOT symbols will be
-     ;; also keyword in feature expressions.
+     ;; Macrocharacters for  conditional reading #+  and #- bind the  current package to  KEYWORD so
+     ;; features are  correctly interned.  For this  reason, AND, OR  and NOT  symbols will  also be
+     ;; keyword in feature expressions.
      (ecase (first expression)
        (:and
         (every #'eval-feature-expression (rest expression)))
@@ -228,7 +224,7 @@
   (%read-char stream)
   (let ((ch (%read-char stream)))
     (case ch
-      (#\'
+      (#\apostrophe
        (list 'function (ls-read stream eof-error-p eof-value t)))
       (#\.
        (eval (ls-read stream)))
@@ -244,7 +240,7 @@
             (dotimes (i index)
               (aset result (decf index) (pop elements)))
             result)
-         (let* ((ix index) ; Can't just use index: the same var would be captured in all fixups
+         (let* ((ix index)      ; Can't just use index: the same var would be captured in all fixups
                 (*make-fixup-function* (lambda ()
                                          (lambda (obj)
                                            (aset result ix obj))))
@@ -312,9 +308,8 @@
                    (progn
                      (add-labelled-object id *future-value*)
                      (let ((obj (ls-read stream eof-error-p eof-value t)))
-                       ;; FIXME: somehow the more natural
-                       ;;    (setf (cdr (find-labelled-object id)) obj)
-                       ;; doesn't work
+                       ;; FIXME: somehow the more natural (setf (cdr (find-labelled-object id)) obj)
+                       ;;    doesn't work
                        (rplacd (find-labelled-object id) obj)
                        obj))))
               (#\#
@@ -353,10 +348,9 @@
                 (setf result (concat result (string-upcase (string ch))))))))
     result))
 
-;;; Parse a string of the form NAME, PACKAGE:NAME or
-;;; PACKAGE::NAME and return the name. If the string is of the
-;;; form 1) or 3), but the symbol does not exist, it will be created
-;;; and interned in that package.
+;;; Parse a  string of  the form NAME,  PACKAGE:NAME or  PACKAGE::NAME and return  the name.  If the
+;;; string is of the form  1) or 3), but the symbol does not exist, it  will be created and interned
+;;; in that package.
 (defun read-symbol (string)
   (let ((size (length string))
         package name internalp index)
@@ -551,10 +545,10 @@
               ((char= ch #\()
                (%read-char stream)
                (%read-list stream eof-error-p eof-value))
-              ((char= ch #\')
+              ((char= ch #\apostrophe)
                (%read-char stream)
                (list 'quote (ls-read stream eof-error-p eof-value t)))
-              ((char= ch #\`)
+              ((char= ch #\grave_accent)
                (%read-char stream)
                (list 'backquote (ls-read stream eof-error-p eof-value t)))
               ((char= ch #\")

--- a/src/toplevel.lisp
+++ b/src/toplevel.lisp
@@ -284,12 +284,11 @@
        nil)))
 
 
-;;; Basic *standard-output* stream. This will usually be overriden by
+;;; Basic *standard-output*  stream. This  will usually be  overriden by
 ;;; web or node REPL.
 ;;;
-;;; TODO: Cache character operation so they result in a single call to
+;;; TODO: Cache character  operation so they result in a  single call to
 ;;; console.log.
-;;;
 (setq *standard-output*
       (vector 'stream
               (lambda (ch)


### PR DESCRIPTION
This is a number of spot-patches to throw Error objects, often adding additional details to the existing (throw string) messages, to aid debugging.