### PR TITLE
[Experimental] Clojure-like foreign method call syntax

### DIFF
--- a/src/read.lisp
+++ b/src/read.lisp
@@ -568,6 +568,10 @@
                    (list 'unquote (ls-read stream eof-error-p eof-value t))))
               ((char= ch #\#)
                (read-sharp stream eof-error-p eof-value))
+              ((char= ch #\.)
+               (let ((descriptor (subseq (read-until stream #'terminalp) 1))
+                     (object (ls-read stream)))
+                 `(oget ,object ,descriptor)))
               (t
                (let ((string (read-escaped-until stream #'terminalp)))
                  (unless *read-skip-p*


### PR DESCRIPTION
**This PR is not needed to be merged to master.**

I've experimentally implemented a Clojure-like foreign method call syntax with casual hack.

Currently we can call foreign methods in terms of internal `oget` fanction as:

    ((oget droparea "on") "dragleave"
      #'(lambda (evt)
          ((oget evt "stopPropagation"))
          ((oget evt "preventDefault"))
          ((oget droparea "removeClass") "highlight")))))

The introduced syntax enables us code the same thing as:

    (.on droparea "dragleave"
      #'(lambda (evt)
          (.stopPropagation evt)
          (.preventDefault evt)
          (.removeClass droparea "highlight")))))

which, off course there would be things left to be considered, greatly increase the feasibility to employ JSCL in practical web applications.

