### PR TITLE
Fix let* bug

### DIFF
--- a/src/prelude.js
+++ b/src/prelude.js
@@ -314,6 +314,7 @@ internals.Symbol = function(name, package_name){
   this.package = package_name;
   this.value = undefined;
   this.fvalue = internals.unboundFunction;
+  this.stack = [];
 };
 
 internals.symbolValue = function (symbol){

--- a/tests/variables.lisp
+++ b/tests/variables.lisp
@@ -6,6 +6,6 @@
               (setq *x* 1)
               (test (= *x* 1))
               2)))
-  (expected-failure (= *x* 2)))
+  (test (= *x* 2)))
 
-(expected-failure (= *x* 1))
+(test (= *x* 1))


### PR DESCRIPTION
This pull request fixes in which order `let*` evaluates and order the bindings.

Previously, `let*` created the binding before the value was evaluated. That broke in the case where the symbol value is changed in the value part of the form, which does not sound a good practice, but still.
