### PR TITLE
Prevent stacks of JS-LISP trampolines

### DIFF
--- a/src/prelude.js
+++ b/src/prelude.js
@@ -218,12 +218,17 @@ internals.lisp_to_js = function (x) {
     return false;
   else if (typeof x == 'function'){
     // Trampoline calling the Lisp function
-    return (function(){
-      var args = Array.prototype.slice.call(arguments);
-      for (var i in args)
-        args[i] = internals.js_to_lisp(args[i]);
-      return internals.lisp_to_js(x.apply(this, [internals.pv].concat(args)));
-    });
+    if("jscl_original" in x) {
+        return x.jscl_original
+    } else {
+        return( function(){
+            var args = Array.prototype.slice.call(arguments);
+            for (var i in args)
+                args[i] = internals.js_to_lisp(args[i]);
+            return internals.lisp_to_js(x.apply(this, [internals.pv].concat(args)));
+        });
+    }
+    return answer;
   }
   else return x;
 };


### PR DESCRIPTION
When a function from the JS world enters Lisp, the original JS function is saved as jscl_original.  This values should be returned when going the other way around, so that the JS function customisation remain available (e.g. ES6 objects).