### PR TITLE
Fix: floor function returns multiple values

### DIFF
--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -54,7 +54,9 @@
 
 
 (defun floor (x &optional (y 1))
-  (%floor (/ x y)))
+  (let ((quotient (%floor (/ x y))))
+    (values quotient
+            (- x (* quotient y)))))
 
 (defun ceiling (x &optional (y 1))
   (%ceiling (/ x y)))

--- a/tests/misc.lisp
+++ b/tests/misc.lisp
@@ -1,3 +1,4 @@
 ;; STEP macro
+#+jscl
 (test (= 4
          (step (progn (setf x 5) (decf x)))))

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -90,15 +90,23 @@
 
 ;;; Floor, Ceil, Truncate and Round
 
-(test (= (floor 0) 0))
-(test (= (floor 1) 1))
-(test (= (floor -1) -1))
-(test (= (floor 1.2) 1))
-(test (= (floor -1.2) -2))
-(test (= (floor 4 3) 1))
-(test (= (floor -4 3) -2))
-(test (= (floor 4 -3) -2))
-(test (= (floor -4 -3) 1))
+(test (equal (multiple-value-list (floor 0))        '(0 0)))
+(test (equal (multiple-value-list (floor 1))        '(1 0)))
+(test (equal (multiple-value-list (floor -1))       '(-1 0)))
+(test (equal (multiple-value-list (floor 4 3))      '(1 1)))
+(test (equal (multiple-value-list (floor -4 3))     '(-2 2)))
+(test (equal (multiple-value-list (floor 4 -3))     '(-2 -2)))
+(test (equal (multiple-value-list (floor -4 -3))    '(1 -1)))
+
+(test (multiple-value-bind (quotient reminder)
+          (floor 1.2)
+        (and (= quotient 1)
+             (= (+ (* quotient 1) reminder) 1.2))))
+
+(test (multiple-value-bind (quotient reminder)
+          (floor -1.2)
+        (and (= quotient -2)
+             (= (+ (* quotient 1) reminder) -1.2))))
 
 (test (= (ceiling 0) 0))
 (test (= (ceiling 1) 1))


### PR DESCRIPTION
Changes the `floor` function to return multiple values, following the implementation of @t-cool @cxxxr  in the issue #301.

Additionally, add some tests cases to cover the new functionality.

It also fixed `run-tests-in-host` so validate this against SBCL.
