### PR TITLE
Vkm fix format function

### DIFF
--- a/tests/format.lisp
+++ b/tests/format.lisp
@@ -20,3 +20,15 @@ a" (format nil "a~%a")))
 (test (string= " " (format nil "~C" #\space)))
 (test (string= "Space" (format nil "~:C" #\space)))
 (test (string= "Newline" (format nil "~:C" #\newline)))
+
+;;; Premature end of control string
+(test 
+ (string= "Premature end of control string \"result ~\"" 
+          (let ((result))
+              (handler-case 
+                  (progn 
+                      (format nil "its ok ~~")
+                      (format nil "result ~"))
+                (error (msg)
+                    (setq result (format nil (car (jscl::!condition-args msg)) (cadr (jscl::!condition-args msg))))))
+              result)))


### PR DESCRIPTION
Prevented "out of range" error in case of premature end of control
string ie "~a ~".
See #278