### PR TITLE
fix for bug in reduce when only one element is in the sequence

### DIFF
--- a/src/sequence.lisp
+++ b/src/sequence.lisp
@@ -320,10 +320,10 @@
 (defun one-args-reduce (function element from-end initial-value initial-value-p)
   (if from-end
       (if initial-value-p
-          (funcall function initial-value element)
+          (funcall function element initial-value)
           element)
       (if initial-value-p
-          (funcall function element initial-value)
+          (funcall function initial-value element)
           element)))
 
 (defun reduce (function sequence &key (key #'identity) from-end (start 0) end (initial-value nil initial-value-p))

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -137,6 +137,8 @@
 (test (equal 3 (reduce #'(lambda () (error "When reducing a sequence with one element the function should not be called"))
                        #(1 2 3 4) :start 2 :end 3)))
 
+(test (equal (reduce #'cons '(1) :initial-value 0) '(0 . 1)))
+
 ;; The following tests reduced reduce were copied from ANSI CL TESTS.
 (test (equal (reduce #'cons '(a b c d e f) :start 1 :end 4 :from-end t)
              '(b c . d)))


### PR DESCRIPTION
issue #261 