### PR TITLE
This fixes #277: an error was printed in the web REPL on empty input

### DIFF
--- a/repl-web/repl.lisp
+++ b/repl-web/repl.lisp
@@ -63,6 +63,7 @@
             0)))
 
 (defun toplevel ()
+  (#j:jqconsole:RegisterMatching "(" ")" "parents")
   (let ((prompt (format nil "~a> " (package-name *package*))))
     (#j:jqconsole:Write prompt "jqconsole-prompt"))
   (flet ((process-input (input)


### PR DESCRIPTION
Both REPLs now display

; No value

when empty input is provided