### PR TITLE
(constantp nil) should return t

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -451,7 +451,7 @@
   (cond
     ((symbolp x)
      (cond
-       ((eq x t) t)
+       ((or (eq x t) (eq x nil)) t)
        ((setq x nil) t)))
     ((atom x)
      t)


### PR DESCRIPTION
http://www.lispworks.com/documentation/HyperSpec/Body/f_consta.htm#constantp

" Constant variables, such as keywords, symbols defined by Common Lisp as constant (such as nil, t, and pi), "

Nil returned nil before, oops.