### PR TITLE
(constantp nil) should return t

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -452,7 +452,7 @@
     ((symbolp x)
      (cond
        ((eq x t) t)
-       ((setq x nil) t)))
+       ((eq x nil) t)))
     ((atom x)
      t)
     (t


### PR DESCRIPTION
http://www.lispworks.com/documentation/HyperSpec/Body/f_consta.htm#constantp
" Constant variables, such as keywords, symbols defined by Common Lisp as constant (such as nil, t, and pi), and symbols declared as constant by the user in the indicated environment using defconstant are always considered constant forms and must be recognized as such by constantp."

And now it does. It looks like setq was just a typo for eq.