### PR TITLE
add with-input-from-string

### DIFF
--- a/src/stream.lisp
+++ b/src/stream.lisp
@@ -79,6 +79,11 @@
      :kind 'string-stream
      :data buffer)))
 
+(defmacro with-input-from-string ((var string) &body body)
+  ;; TODO: &key start end index
+  `(let ((,var (make-string-input-stream ,string)))
+     ,@body))
+
 (defun get-output-stream-string (stream)
   (prog1 (stream-data stream)
     (setf (stream-data stream) (make-string 0))))


### PR DESCRIPTION
file://localhost/Applications/LispWorks%207.1%20(64-bit)/Library/lib/7-1-0-0/manual/online/CLHS/Body/m_w_in_f.htm

It is not complete because there is an unimplemented feature in make-string-input-stream.
