### PR TITLE
Vkm add some missing  functions (#330)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.fasl
 *.fas
 *.lx64fsl
+*.wx64fsl
 *.lib
 \#*
 jscl.js

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -114,9 +114,9 @@
          ;; get-setf-expansion by consulting this register of SETF
          ;; definitions.
          (let ((sfn 
-                (let ((pname (write-to-string name)))
-                  (intern pname
-                          (symbol-package (cadr name))))))
+                 (let ((pname (write-to-string name)))
+                   (intern pname
+                           (symbol-package (cadr name))))))
            `(progn
               (%defun ,sfn ,args ,@body)
               (define-setf-expander ,(cadr name) (&rest arguments)
@@ -125,15 +125,15 @@
                                         (gensym))
                                       arguments))
                       (g!newvalue (gensym))
-                      (g!setter ',sfn))
+                      (g!setter ',sfn)
+                      (g!getter ',(cadr name)))
                   (values 
                    (list g!args)
                    arguments
                    (list g!newvalue)
                    `(,g!setter ,g!newvalue ,@arguments)
-                   nil))))))
+                   `(,g!getter ,@arguments)))))))
         (t (error "defun ~a unknow function specifier" name))))
-;;;
 
 (defmacro return (&optional value)
   `(return-from nil ,value))

--- a/src/list.lisp
+++ b/src/list.lisp
@@ -489,14 +489,14 @@
 
 ;;; makeset
 (defun makeset (lst &key (test #'eq))
-    (prog ((result)
-           (seq lst))
-     feed
-       (when (null seq) (return (reverse result)))
-       (if (not (member (car seq) result :test test))
-           (setq result (cons (car seq) result)))
-       (setq seq (cdr seq))
-       (go feed)))
+  (prog ((result)
+         (seq lst))
+   feed
+     (when (null seq) (return (reverse result)))
+     (if (not (member (car seq) result :test test))
+         (setq result (cons (car seq) result)))
+     (setq seq (cdr seq))
+     (go feed)))
 
 ;;; union
 (defun union (list1 list2 &key key (test #'eq))

--- a/src/list.lisp
+++ b/src/list.lisp
@@ -475,3 +475,63 @@
 (defun mapcon (function list &rest more-lists)
   "Apply FUNCTION to successive CDRs of lists. Return NCONC of results."
   (map1 function (cons list more-lists) :nconc nil))
+
+
+;;; set-difference
+(defun set-difference (list1 list2 &key key (test #'eq))
+    (cond (list2
+           (let ((result '()))
+               (dolist (it list1)
+                   (when (not (member it list2 :key key :test test))
+                       (push it result)))
+               result))
+          (t list1)))
+
+;;; makeset
+(defun makeset (lst &key (test #'eq))
+    (prog ((result)
+           (seq lst))
+     feed
+       (when (null seq) (return (reverse result)))
+       (if (not (member (car seq) result :test test))
+           (setq result (cons (car seq) result)))
+       (setq seq (cdr seq))
+       (go feed)))
+
+;;; union
+(defun union (list1 list2 &key key (test #'eq))
+    (cond ((and list1 list2)
+           (let ((result (makeset list2 :test #'equal)))
+               (dolist (it (makeset list1 :test #'equal))
+                   (when (not (member it list2 :key key :test test))
+                       (push it result)))
+               result))
+          (list1)
+          (list2)))
+
+
+;;; sort
+;;; https://en.wikipedia.org/wiki/Selection_sort
+(defun sort (lst fn &key (key 'identity))
+    (if (endp lst) '()
+        (block selection-sort
+            (let* ((j lst)
+                   (imin j))
+                (while t
+                    (when (null j)
+                        (return lst))
+                    (tagbody
+                       (let ((i (cdr j)))
+                           (while t
+                               (if (null i) (return nil))
+                               (if (funcall fn
+                                            (funcall key (car i))
+                                            (funcall key (car imin)))
+                                   (setq imin i))
+                               (setq i (cdr i))))
+                       (when (not (eq imin j))
+                           (let ((swap-j (car j))
+                                 (swap-imin (car imin)))
+                               (setf (car j) swap-imin (car imin) swap-j))))
+                    (setq j (cdr j) imin j)))) ))
+

--- a/src/list.lisp
+++ b/src/list.lisp
@@ -479,13 +479,13 @@
 
 ;;; set-difference
 (defun set-difference (list1 list2 &key key (test #'eq))
-    (cond (list2
-           (let ((result '()))
-               (dolist (it list1)
-                   (when (not (member it list2 :key key :test test))
-                       (push it result)))
-               result))
-          (t list1)))
+  (cond (list2
+         (let ((result '()))
+           (dolist (it list1)
+             (when (not (member it list2 :key key :test test))
+               (push it result)))
+           result))
+        (t list1)))
 
 ;;; makeset
 (defun makeset (lst &key (test #'eq))

--- a/src/list.lisp
+++ b/src/list.lisp
@@ -500,14 +500,14 @@
 
 ;;; union
 (defun union (list1 list2 &key key (test #'eq))
-    (cond ((and list1 list2)
-           (let ((result (makeset list2 :test #'equal)))
-               (dolist (it (makeset list1 :test #'equal))
-                   (when (not (member it list2 :key key :test test))
-                       (push it result)))
-               result))
-          (list1)
-          (list2)))
+  (cond ((and list1 list2)
+         (let ((result (makeset list2 :test #'equal)))
+           (dolist (it list1)
+             (when (not (member it list2 :key key :test test))
+               (push it result)))
+           result))
+        (list1)
+        (list2)))
 
 
 ;;; sort

--- a/src/list.lisp
+++ b/src/list.lisp
@@ -510,28 +510,43 @@
         (list2)))
 
 
-;;; sort
-;;; https://en.wikipedia.org/wiki/Selection_sort
+;;; selection sort algoritm
+;;; see https://en.wikipedia.org/wiki/Selection_sort
+;;; also many examples: http://rosettacode.org/wiki/Category:Sorting_Algorithms
+;;;
+;;; Release note:
+;;;
+;;; Usually i use (#j:sort). Implementation of this function is done as it is used in CLOS.
+;;; Considering that  in two last years, no one has opened issue about the absence of a sort function,
+;;; I consider the price of the question to be minimal. The selection criteria is very simple:
+;;; a) do not used additional memory b) without recursion c)simple pseudocode and fast implementation.
+;;; So, was implemented selection_sort algoritm. If somebody needs a better sort, they can do it later.
+;;;
+;;; VKM
+;;;
 (defun sort (lst fn &key (key 'identity))
-    (if (endp lst) '()
-        (block selection-sort
-            (let* ((j lst)
-                   (imin j))
-                (while t
-                    (when (null j)
-                        (return lst))
-                    (tagbody
-                       (let ((i (cdr j)))
-                           (while t
-                               (if (null i) (return nil))
-                               (if (funcall fn
-                                            (funcall key (car i))
-                                            (funcall key (car imin)))
-                                   (setq imin i))
-                               (setq i (cdr i))))
-                       (when (not (eq imin j))
-                           (let ((swap-j (car j))
-                                 (swap-imin (car imin)))
-                               (setf (car j) swap-imin (car imin) swap-j))))
-                    (setq j (cdr j) imin j)))) ))
+  (if (vectorp lst) 
+      (error "Array sort yet not implemented."))
+  (if (endp lst) 
+      '()
+      (block selection-sort
+        (let* ((j lst)
+               (imin j))
+          (while t
+            (when (null j)
+              (return lst))
+            (tagbody
+               (let ((i (cdr j)))
+                 (while t
+                   (if (null i) (return nil))
+                   (if (funcall fn
+                                (funcall key (car i))
+                                (funcall key (car imin)))
+                       (setq imin i))
+                   (setq i (cdr i))))
+               (when (not (eq imin j))
+                 (let ((swap-j (car j))
+                       (swap-imin (car imin)))
+                   (setf (car j) swap-imin (car imin) swap-j))))
+            (setq j (cdr j) imin j)))) ))
 

--- a/src/sequence.lisp
+++ b/src/sequence.lisp
@@ -229,20 +229,13 @@
     (when (funcall function elt)
       (return-from some t))))
 
-#+nil
-(defun every (function seq)
-  (do-sequence (elt seq)
-    (unless (funcall function elt)
-      (return-from every nil)))
-  t)
-
 ;;; more sequences version
 (defun every (predicate first-seq &rest more-sequences)
-    (apply #'map nil (lambda (&rest seqs)
-                         (when (not (apply predicate seqs))
-                             (return-from every nil)))
-           first-seq more-sequences)
-    t)
+  (apply #'map nil (lambda (&rest seqs)
+                     (when (not (apply predicate seqs))
+                       (return-from every nil)))
+         first-seq more-sequences)
+  t)
 
 
 (defun remove-if (func seq)

--- a/src/sequence.lisp
+++ b/src/sequence.lisp
@@ -461,28 +461,28 @@
 
 ;;; remove duplicates
 (defun %remove-duplicates (seq from-end test test-not key start end)
-    (let ((result)
-          (test-fn test)
-          (sequence (if from-end seq (reverse seq))))
-        (when test-not 
-            (setq test-fn (complement test-not)))
-        (when (or (not (eql start 0))
-                  end)
-            (setq sequence (subseq sequence start end)))
-        (dolist (it sequence)
-            (unless (find (funcall key it) result :key key :test test-fn)
-                (push it result)))
-        (if from-end
-            (reverse result)
-            result)))
+  (let ((result)
+        (test-fn test)
+        (sequence (if from-end seq (reverse seq))))
+    (when test-not 
+      (setq test-fn (complement test-not)))
+    (when (or (not (eql start 0))
+              end)
+      (setq sequence (subseq sequence start end)))
+    (dolist (it sequence)
+      (unless (find (funcall key it) result :key key :test test-fn)
+        (push it result)))
+    (if from-end
+        (reverse result)
+        result)))
 
 (defun remove-duplicates (seq &key from-end (test 'eq) test-not (key 'identity) (start 0) end)
-    (cond ((listp seq)
-           (%remove-duplicates seq from-end test test-not key start end))
-          ((stringp seq)
-           (apply #'concat (%remove-duplicates (vector-to-list seq) from-end test test-not key start end)))
-          ((vectorp seq)
-           (list-to-vector (%remove-duplicates (vector-to-list seq) from-end test test-not key start end)))
-          (t (error "Its not sequence ~a" seq))))
+  (cond ((listp seq)
+         (%remove-duplicates seq from-end test test-not key start end))
+        ((stringp seq)
+         (apply #'concat (%remove-duplicates (vector-to-list seq) from-end test test-not key start end)))
+        ((vectorp seq)
+         (list-to-vector (%remove-duplicates (vector-to-list seq) from-end test test-not key start end)))
+        (t (error "Its not sequence ~a" seq))))
 
 

--- a/tests/defun.lisp
+++ b/tests/defun.lisp
@@ -54,3 +54,28 @@
   (let ((qq '(1 2 3)))
     (test (equal '(99 3) (setf (%cadr% qq) 99)))
     (test (equal '(1 99 3) qq))))
+
+;;; push/pop/incf/decf test
+#+jscl
+(progn
+  ;; getter
+  (defun getr (r idx) 
+    (aref r idx))
+  ;; setter
+  (defun (setf getr) (value r idx) 
+    (setf (aref r idx) value))
+  (let ((r #(nil nil nil)))
+    ;; initial values 
+    (setf (getr r 0) 1)
+    (setf (getr r 1) (list :tail))
+    ;; push
+    (dolist (it '(3 2 1)) 
+      (push it (getr r 2)))
+    ;; pop
+    (dotimes (it (length (getr r 2)))
+      (push (pop (getr r 2)) (getr r 1)))
+    ;; incf
+    (dotimes (i 10)
+      (incf (getr r 0)))
+    (equal '(11 (3 2 1 :tail) nil) 
+           (vector-to-list r))))

--- a/tests/list.lisp
+++ b/tests/list.lisp
@@ -253,3 +253,54 @@
 ;; MAKE-LIST
 (test (equal (make-list 5) '(nil nil nil nil nil)))
 (test (equal (make-list 3 :initial-element 'rah) '(rah rah rah)))
+
+
+;;; set-difference test
+(let ((lst1 (list "A" "b" "C" "d"))
+      (lst2 (list "a" "B" "C" "d")))
+    (test (equal 
+           (list
+            (equal (set-difference lst1 lst2) (list "d" "C" "b" "A"))
+            (equal (set-difference lst1 lst2 :test 'equal) (list "b" "A"))
+            (equal (set-difference lst1 lst2 :test #'string=)  (list "b" "A")))
+           (list t t t)))) 
+
+
+;; SORT
+#+jscl
+(test 
+ (equal (apply 'jscl::concat
+               (sort (jscl::vector-to-list "cdbaxaybzcd") #'char-lessp))
+        "aabbccddxyz"))
+
+#+jscl
+(test 
+ (let ((sorted (apply 'jscl::concat
+                      (sort (jscl::vector-to-list "cdbaxaybzcd") #'char-lessp))))
+     (equal (remove-duplicates sorted :test #'char-equal :from-end t) "abcdxyz")))
+
+
+(test 
+ (equal (sort '((1 2 3) (4 5 6) (7 8 9))  #'> :key #'car)
+        '((7 8 9) (4 5 6) (1 2 3))))
+
+
+;;; union
+
+(test
+ (equal (union '(a b c) '(f a d))
+        '(C B F A D)))
+
+
+(test 
+ (equal (union '((x 5) (y 6)) '((z 2) (x 4) (z 2)) 
+               :key #'car 
+               :test (lambda (x y) (equal (car x) y)))
+        '((Y 6) (Z 2) (X 4))))
+
+
+(test
+ (let ((lst1 (list 1 2 '(1 2) "a" "b"))
+       (lst2 (list 2 3 '(2 3) "B" "C")))
+     (equal (union lst1 lst2) 
+            '("b" "a" (1 2) 1 2 3 (2 3) "B" "C"))))

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -273,3 +273,20 @@
    (list acc result))
  '((3 2 1) t))
  
+
+
+;;; REMOVE-DUPLICATES
+(test 
+ (equal
+  (list
+   (equal (remove-duplicates "aBcDAbCd" :test #'char-equal :from-end t) "aBcD")
+   (equal (remove-duplicates '(a b c b d d e)) '(A C B D E))
+   (equal (remove-duplicates '(a b c b d d e) :from-end t) '(A B C D E))
+   (equal (remove-duplicates '((foo #\a) (bar #\%) (baz #\A))
+                             :test #'char-equal :key #'cadr) '((BAR #\%) (BAZ #\A)))
+   (equal (remove-duplicates '((foo #\a) (bar #\%) (baz #\A)) 
+                             :test #'char-equal :key #'cadr :from-end t) '((FOO #\a) (BAR #\%))))
+  (list t t t t t)))
+
+
+


### PR DESCRIPTION
## What
- `sort` (implementation only for lists, others in TODO) in list.lisp
- `set-difference` in list.lisp
- `union` in list.lisp
- `remove-duplicates` in sequence.lisp 
- `every` in sequence.lisp replaced by more sequences version

## Reasons
- all of these functions are used in clos release
- ANSI Compliance
