### PR TITLE
Fix progn with multiple values

### DIFF
--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -697,11 +697,9 @@
      (convert ,form)))
 
 (define-compilation progn (&rest body)
-  (if (null (cdr body))
-      (convert (car body) *multiple-value-p*)
-      `(progn
-         ,@(append (mapcar #'convert (butlast body))
-                   (list (convert (car (last body)) t))))))
+  `(progn
+     ,@(append (mapcar #'convert (butlast body))
+               (list (convert (car (last body)) *multiple-value-p*)))))
 
 (define-compilation macrolet (definitions &rest body)
   (let ((*environment* (copy-lexenv *environment*)))

--- a/tests/multiple-values.lisp
+++ b/tests/multiple-values.lisp
@@ -1,0 +1,10 @@
+;; Regression for issue
+;;   https://github.com/jscl-project/jscl/issues/341
+;;
+;; This is written in a block/return in an attempt to isolate the
+;; problem from the context of the `test` macro:
+(defun test-progn-multiple-value ()
+  (block nil
+    (return (eq 42 (progn nil (values 42))))))
+
+(test (test-progn-multiple-value))


### PR DESCRIPTION
This pull request fixes the bug #341 , about `progn` interacting badly with multiple values in some cases.

As an exercise of sharing knowledge/workflow, I'll add notes that I collected during the debugging session and how I got there. I hope it helps!

### Debugging session

#### Narrowing down the problem

After playing with the snippet a bit, trying different combinations, I was able to reduce to the following code:

```lisp
(print
  (progn 
    3
    (char= #\2 #\})))
; fails! prints #(NIL)
```

I noticed that this does not happen without `print`. I replaced `print` with `/log` to see it in the console, and `#(NIL)` seems to be a representation for a multiple value return!

```lisp
(jscl::/log
  (progn 
    3
    (char= #\2 #\})))

; [i…s.Symbol, multiple-value: true]
```

The problem doesn't seem to happen for functions other than `char=.`

Noticing that the output in the REPL is good without `print`, it means I won't trust print this time.
Let's check the return value of `char=`:

```lisp
(jscl::/log (char= #\2 #\3))
; internals.Symbol {name: "NIL", package: {…}, value: i…s.Symbol, fvalue: ƒ, stack: Array(0), …}
;   seems ok
```
    
It's strange. I'll continue following the lead of multiple values:

```lisp
(print (progn (values nil)))
; works

(print (progn 2 (values nil)))
; fails!!
```

Ok, that is interesting. However `char=` doesn't return multiple
values! We'll come back to it later.

I tried looking at the compiler output without success. I'll focus now
on `rogn`. Why `progn` with just 1 form worked, but failed with
multiple forms?

Let's look at the implementation

```lisp
(define-compilation progn (&rest body)
  (if (null (cdr body))
      (convert (car body) *multiple-value-p*)
      `(progn
         ,@(append (mapcar #'convert (butlast body))
                   (list (convert (car (last body)) t))))))
```

aha! Ok, we see an interesting difference. The first branch (single
element) is using `*multiple-value-p*` while the second one is just
passing `t`.

There may be a reason for it, but I suspect that is the cause of the
issue. I don't understand either why we have two branches at all in
`progn`. The common question here is whether I forgot to write a
comment explaining the reason or I was just silly :-)

Reading the comment about `*multiple-value-p` is a good refresher to
know how this works:

```lisp
;;; A Form can return a multiple values object calling VALUES, like
;;; values(arg1, arg2, ...). It will work in any context, as well as
;;; returning an individual object. However, if the special variable
;;; `*multiple-value-p*' is NIL, is granted that only the primary
;;; value will be used, so we can optimize to avoid the VALUES
;;; function call.
```

That `values` variable can be one of two functions: `pv` (primary
value) or `mv` (multiple value). It seems that `progn` calling the
last form with `t` will make the `values` function somewhere to be
`mv`, but `print` (or any function call) is not ready for that and
interprets it as an array.

A quick check changing `t` and passing `*multiple-value-p*` seems to
indeed solve the issue. So I'll write test for it and simplify `progn`
to use a single branch.


#### Adding a regression test for it

I thoguht this would be trivial, but quite far. Test framework is also
compiled and it is preventing me from triggering the bug!

Look at this:

```lisp
(test
  ;; Oops! this is NIL in the REPL but T in the tests!
  (eq 42 (progn nil (values 42)))
  )
```

We need to make the test case more robust so it is not affected (so
much) for the context of the `test` macro.

This did it:

```lisp
(defun test-progn-multiple-value ()
  (block nil
    (return (eq 42 (progn nil (values 42))))))

(test (test-progn-multiple-value))
```

Does it sound familiar?  🙂 that may be related somehow to `char=`..?

Ok, **now we are ready to make the fix!**

#### `char=` retrurns multiple values

Going back to what is special about `char=` in the first example.  It is not just because it is a function call. After all

```lisp
(defun f () 42)
(print (progn nil (f)))   ;  ok!
```
seems correct. But as soon as we introduce a `return`, same thing happens:

```lisp
(defun f () (return-from f 42))
(print (progn nil (f))) ; break!
```
I am not going deeper into this (although I should), because my fix also solves this case. But my hypotehsis is that `(defun f () 42)` is optimized so there is no call to `values(42)` at all. However, when `return-from` is introduced, there is such a call.

That means that `f` will provide a single value if called with `values=pv` and multiple values if `values=mv`.  But the issue in `progn` will trigger the call to `f` with `values=mv`.
