### PR TITLE
Fix load on browsers (variable BIN unbound)

### DIFF
--- a/src/load.lisp
+++ b/src/load.lisp
@@ -145,7 +145,7 @@
     (t
      (when sync
        (warn "sync mode only for node/electron platform~%will be used async mode"))
-     (when (or output bin)
+     (when (or output hook)
        (warn "output/hook options only for node/electron platform"))
      (loader-browser-mode name verbose)))
   (values))


### PR DESCRIPTION
When you try to load a file, the load function errors whether the file actually exists or not.

```
Welcome to JSCL 0.7.0 (built on 2 January 2019)

JSCL is a Common Lisp implementation on Javascript.
For more information, visit the project page at GitHub.

CL-USER> (load "foo.lisp")

ERROR: Variable BIN is unbound.
CL-USER>  
```