### PR TITLE
read-whole-file: Trim array to character count

### DIFF
--- a/jscl.lisp
+++ b/jscl.lisp
@@ -145,9 +145,10 @@
 
 (defun read-whole-file (filename)
   (with-open-file (in filename)
-    (let ((seq (make-array (file-length in) :element-type 'character)))
-      (read-sequence seq in)
-      (substitute-if #\Space #'(lambda (char) (eql char #\Return)) seq))))
+    (let* ((seq (make-array (file-length in) :element-type 'character))
+           (char-count (read-sequence seq in))
+           (seq1 (substitute-if #\Space #'(lambda (char) (eql char #\Return)) seq)))
+      (subseq seq1 0 char-count))))
 
 (defun !compile-file (filename out &key print)
   (let ((*compiling-file* t)


### PR DESCRIPTION
When a source file contains non-ASCII characters (which are encoded with multiple bytes), the `read-whole-file` function seems to add extra null characters at the end of the array it returns. And this causes issues at the compilation stage.

The array is allocated to have the same length as the length of the file but `file-length` returns the length in bytes in most implementations irrespective of the element type of the stream.

```
* (read-whole-file "greek.lisp")

"(print \"αβγ\")
"
* (map 'list #'char-code (read-whole-file "greek.lisp"))

(40 112 114 105 110 116 32 34 945 946 947 34 41 10 0 0 0)
* 
```