### PR TITLE
Sharpsigns #B, #O, #X - reader features

### DIFF
--- a/src/read.lisp
+++ b/src/read.lisp
@@ -608,10 +608,10 @@
 
 
 #+jscl
-(defun parse-integer (string &key junk-allowed)
+(defun parse-integer (string &key (start 0) end (radix 10) junk-allowed)
   (multiple-value-bind (num index)
-      (!parse-integer string junk-allowed)
-    (if num
+      (jscl::!parse-integer string start end radix junk-allowed)
+    (if (or num junk-allowed)
         (values num index)
         (error "Junk detected."))))
 

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -533,7 +533,7 @@
       ;; XXX: Use FLOAT when implemented.
       (/ (* sign (expt 10.0 (* exponent-sign exponent)) number) divisor 1.0))))
 
-(defun !parse-integer (string junk-allow)
+#+nil(defun !parse-integer (string junk-allow)
   (block nil
     (let ((value 0)
           (index 0)

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -533,42 +533,6 @@
       ;; XXX: Use FLOAT when implemented.
       (/ (* sign (expt 10.0 (* exponent-sign exponent)) number) divisor 1.0))))
 
-#+nil(defun !parse-integer (string junk-allow)
-  (block nil
-    (let ((value 0)
-          (index 0)
-          (size (length string))
-          (sign 1))
-      ;; Leading whitespace
-      (while (and (< index size)
-                  (whitespacep (char string index)))
-        (incf index))
-      (unless (< index size) (return (values nil 0)))
-      ;; Optional sign
-      (case (char string 0)
-        (#\+ (incf index))
-        (#\- (setq sign -1)
-             (incf index)))
-      ;; First digit
-      (unless (and (< index size)
-                   (setq value (digit-char-p (char string index))))
-        (return (values nil index)))
-      (incf index)
-      ;; Other digits
-      (while (< index size)
-        (let ((digit (digit-char-p (char string index))))
-          (unless digit (return))
-          (setq value (+ (* value 10) digit))
-          (incf index)))
-      ;; Trailing whitespace
-      (do ((i index (1+ i)))
-          ((or (= i size) (not (whitespacep (char string i))))
-           (and (= i size) (setq index i))))
-      (if (or junk-allow
-              (= index size))
-          (values (* sign value) index)
-          (values nil index)))))
-
 
 (defun !parse-integer (string start end radix junk-allow)
   (block nil

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -341,6 +341,22 @@
          (t
           (error "Invalid dispatch character after #")))))))
 
+(defun sharp-radix-reader (ch stream)
+  ;; Sharp radix base #\B #\O #\X
+  (let* ((fixed-base (assoc ch jscl::*fixed-radix-bases*))
+	       (base (cond (fixed-base (cdr fixed-base))
+		                 (t (error "No radix base in #~A" ch))))
+         (*read-base* base)
+         (number nil)
+         (string (read-until stream #'terminalp)))
+    (setq number (read-integer string))
+    (unless number
+      (error "#~c: bad base(~d) digit at ~s~%"
+             ch
+             base
+             string))
+    number))
+
 (defun unescape-token (x)
   (let ((result ""))
     (dotimes (i (length x))

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -20,6 +20,12 @@
 
 ;;;; Reader
 
+#+jscl(defvar *read-base* 10)
+
+;;; Reader radix bases
+(defvar *fixed-radix-bases* '((#\B . 2) (#\b . 2) (#\o . 8) (#\O . 8) (#\x . 16) (#\X . 16)))
+
+
 ;;; If it is not NIL, we do not want to read the expression but just
 ;;; ignore it. For example, it is used in conditional reads #+.
 (defvar *read-skip-p* nil)

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -569,6 +569,44 @@
           (values (* sign value) index)
           (values nil index)))))
 
+
+(defun !parse-integer (string start end radix junk-allow)
+  (block nil
+    (let ((value 0)
+          (index start)
+          (size (or end (length string)))
+          (sign 1))
+      ;; Leading whitespace
+      (while (and (< index size)
+                  (whitespacep (char string index)))
+             (incf index))
+      (unless (< index size) (return (values nil 0)))
+      ;; Optional sign
+      (case (char string 0)
+        (#\+ (incf index))
+        (#\- (setq sign -1)
+         (incf index)))
+      ;; First digit
+      (unless (and (< index size)
+                   (setq value (digit-char-p (char string index) radix)))
+        (return (values nil index)))
+      (incf index)
+      ;; Other digits
+      (while (< index size)
+             (let ((digit (digit-char-p (char string index) radix)))
+               (unless digit (return))
+               (setq value (+ (* value radix) digit))
+               (incf index)))
+      ;; Trailing whitespace
+      (do ((i index (1+ i)))
+          ((or (= i size) (not (whitespacep (char string i))))
+           (and (= i size) (setq index i))))
+      (if (or junk-allow
+              (= index size))
+          (values (* sign value) index)
+          (values nil index)))))
+
+
 #+jscl
 (defun parse-integer (string &key junk-allowed)
   (multiple-value-bind (num index)

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -425,23 +425,6 @@
               symbol
               (error "The symbol `~S' is not external in the package ~S." name package))))))
 
-#+nil(defun read-integer (string)
-  (let ((sign 1)
-        (number nil)
-        (size (length string)))
-    (dotimes (i size)
-      (let ((elt (char string i)))
-        (cond
-          ((digit-char-p elt)
-           (setq number (+ (* (or number 0) 10) (digit-char-p elt))))
-          ((zerop i)
-           (case elt
-             (#\+ nil)
-             (#\- (setq sign -1))
-             (t (return-from read-integer))))
-          ((and (= i (1- size)) (char= elt #\.)) nil)
-          (t (return-from read-integer)))))
-    (and number (* sign number))))
 
 (defun read-integer (string)
   (let ((base *read-base*)

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -296,6 +296,9 @@
                (push (subseq descriptor start) subdescriptors)
                `(oget *root* ,@(reverse subdescriptors)))
            (push (subseq descriptor start end) subdescriptors))))
+      ;; Sharp radix 
+      ((#\B #\b #\O #\o #\X #\x)
+       (sharp-radix-reader ch stream))
       (#\|
        (labels ((read-til-bar-sharpsign ()
                   (do ((ch (%read-char stream) (%read-char stream)))

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -422,7 +422,7 @@
               symbol
               (error "The symbol `~S' is not external in the package ~S." name package))))))
 
-(defun read-integer (string)
+#+nil(defun read-integer (string)
   (let ((sign 1)
         (number nil)
         (size (length string)))
@@ -439,6 +439,28 @@
           ((and (= i (1- size)) (char= elt #\.)) nil)
           (t (return-from read-integer)))))
     (and number (* sign number))))
+
+(defun read-integer (string)
+  (let ((base *read-base*)
+	      (negative nil)
+	      (number 0)
+	      (start 0)
+	      (end (length string)))
+    (when (eql #\. (char string (1- (length string))))
+      (setf base 10  end (1- end)))
+    (when (or (eql #\+ (char string 0))
+	            (eql #\- (char string 0)))
+      (setq negative (eql #\- (char string 0))
+	          start (1+ start)))
+    (when (not (= (- end start) 0))
+      (do ((idx start (1+ idx)))
+          ((>= idx end)
+           (if negative
+               (- number)
+               number))
+        (let ((weight (digit-char-p (char string idx) base)))
+          (unless weight (return))
+          (setq number (+ (* number base) weight)))))))
 
 (defun read-float (string)
   (block nil

--- a/tests/read.lisp
+++ b/tests/read.lisp
@@ -69,3 +69,44 @@
            (funcall fn0 1 2)
            (funcall fn1 1)
            (funcall fn1 1 :y 2)))))
+
+;;; radix sharp at sequence's
+
+#+jscl
+(test
+ (equal
+  '(t t t t t)
+  (let ((bfv #(#b1 #b10 #b11 #b100 #b101 #b110 #b111 #b1000 #b1001 #b1010))
+        (bfv1 #(#b1 #b10 #b11 'sharp #\# #b100 #b101 #b110 #b111 #b1000 #b1001 #b1010))
+        (bfv2 #(1 2 3 (QUOTE SHARP) #\# 4 5 6 7 8 9 10))
+        (xfv #(#xa001 #xb001 #xc001 #xd001 #xe001 #xf001)))
+    (list (equal
+           ;; correct b->d conversion
+           (jscl::vector-to-list bfv)
+           '(1 2 3 4 5 6 7 8 9 10))
+          (equal
+           ;; correct x->d conversion
+           (jscl::vector-to-list xfv)
+           '(40961 45057 49153 53249 57345 61441))
+          ;; list & sharp tokens -> with sharp reader
+          (equal
+           (jscl::vector-to-list bfv1)
+           '(1 2 3 (QUOTE SHARP) #\# 4 5 6 7 8 9 10))
+          (equal
+           (aref bfv1 3)
+           '(quote sharp))
+          (equal
+           (aref bfv1 4) #\#)  ))))
+
+;;; sharp radix reader from string
+;;; higly likely it redundant but let stay
+#+jscl
+(test
+ (equal
+  '(t)
+  (let* 
+      ((s1 (read-from-string "#(#b1 #b10 #b11 #b100 #b101 #b110 #b111 #b1000 #b1001 #b1010)")))
+    (list
+     (equal
+      (jscl::vector-to-list s1)
+      '(1 2 3 4 5 6 7 8 9 10))))))

--- a/tests/read.lisp
+++ b/tests/read.lisp
@@ -110,3 +110,23 @@
      (equal
       (jscl::vector-to-list s1)
       '(1 2 3 4 5 6 7 8 9 10))))))
+
+;;;
+;;; parse-integer
+;;;
+(test
+ (equal '(t t t t t t)
+        (list
+         (multiple-value-bind (num pos) (parse-integer " 11111000001 " :radix 2 )
+           (equal (list num pos) '(1985 13)))
+         (multiple-value-bind (num pos) (parse-integer " 7C1 " :radix 16 )
+           (equal (list num pos) '(1985 5)))
+         (multiple-value-bind (num pos) (parse-integer " 3701 " :radix 8 )
+           (equal (list num pos) '(1985 6)))
+         ;;clhs examples
+         (multiple-value-bind (num pos) (parse-integer "123")
+           (equal (list num pos) '(123 3)))
+         (multiple-value-bind (num pos) (parse-integer "123"  :start 1 :radix 5)
+           (equal (list num pos) '(13 3)))
+         (multiple-value-bind (num pos) (parse-integer "no-integer" :junk-allowed t)
+           (equal (list num pos) '(nil 0))))))

--- a/tests/read.lisp
+++ b/tests/read.lisp
@@ -130,3 +130,26 @@
            (equal (list num pos) '(13 3)))
          (multiple-value-bind (num pos) (parse-integer "no-integer" :junk-allowed t)
            (equal (list num pos) '(nil 0))))))
+
+;;;
+;;; other fun glitch's
+;;;
+
+#|
+If you remove comments from the following expression there will be a compilation error.
+actually any errors in the types are caught at the compilation stage.
+The correct value can be used in any expressions, as is, at your discretion
+|#
+
+#|
+(let ((fn 
+        (lambda (#xag #xaf) (list #xaa #xaf))))
+  (funcall fn 1 2))
+|#
+
+;;; the correct value can be used in any expressions, as is, at your discretion
+(let ((fn (lambda (#xaa #xaf) (list #xaa #xaf))))
+  (funcall fn 1 2))
+;;; => (170 175)
+
+;;; end

--- a/tests/read.lisp
+++ b/tests/read.lisp
@@ -55,3 +55,17 @@
 
 (let ((*features* '(foo)))
   (test (= (read-from-string "#+foo 1 2)") 1)))
+
+;;; sharp radix reader
+
+(test (string= "this is 1985" (format nil "this is ~a" #o3701)))
+
+(test
+ (equal '((1 2573) (1 2) (1 2573) (1 2))
+        (let ((fn0 (lambda (x &optional (y #x0a0d)) (list x y) ))
+              (fn1 (lambda (x &key (y #x0a0d)) (list x y))))
+          (list
+           (funcall fn0 1)
+           (funcall fn0 1 2)
+           (funcall fn1 1)
+           (funcall fn1 1 :y 2)))))


### PR DESCRIPTION
File  `read.lisp`

1. **#B**, **#O**, **#X** integer type implementation added
2. Fixed `read-integer`
3. Fixed `parse-integer`. Added keys for standard compliance
3. Added test cases

```lisp
CL-USER> (list #o0a #o0d #b010101)
ERROR: #o: bad base(8) digit at "0a"

CL-USER> (list #x0a #x0d #b010101)
(10 13 21)
CL-USER> 
```
