### PR TITLE
Some changes and additions for numbers

### DIFF
--- a/src/compiler/codegen.lisp
+++ b/src/compiler/codegen.lisp
@@ -340,7 +340,7 @@
            (binary-op +          "+"             4    left)
            (binary-op -          "-"             5    left)
            (binary-op <<         "<<"            5    left)
-           (binary-op >>         "<<"            5    left)
+           (binary-op >>         ">>"            5    left)
            (binary-op >>>        ">>>"           5    left)
            (binary-op <=         "<="            6    left)
            (binary-op <          "<"             6    left)

--- a/src/compiler/codegen.lisp
+++ b/src/compiler/codegen.lisp
@@ -323,6 +323,7 @@
            (unary-op post--      "--"            2    right :lvalue t :post t)
            (unary-op not         "!"             2    right)
            (unary-op bit-not     "~"             2    right)
+           (unary-op ~           "~"             2    right)
            ;; Note that the leading space is necessary because it
            ;; could break with post++, for example. TODO: Avoid
            ;; leading space when it's possible.
@@ -354,6 +355,8 @@
            (binary-op !==        "!=="           7    left)
            (binary-op bit-and    "&"             8    left)
            (binary-op bit-xor    "^"             9    left)
+           (binary-op &          "&"             8    left)
+           (binary-op ^          "^"             9    left)
            (binary-op bit-or     "|"            10    left)
            (binary-op and        "&&"           11    left)
            (binary-op or         "||"           12    left)

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1119,6 +1119,10 @@
         (return (<< ,x ,y))
         (return (>> ,x (- ,y))))))
 
+(define-builtin lognot (x)
+  `(selfcall
+    (return (~ ,x))))
+
 
 (defun comparison-conjuntion (vars op)
   (cond

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1113,6 +1113,13 @@
     (return (% ,x ,y))))
 
 
+(define-builtin ash (x y)
+  `(selfcall
+    (if (>= ,y 0)
+        (return (<< ,x ,y))
+        (return (>> ,x (- ,y))))))
+
+
 (defun comparison-conjuntion (vars op)
   (cond
     ((null (cdr vars))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1123,6 +1123,9 @@
   `(selfcall
     (return (~ ,x))))
 
+(define-builtin logand (x y)
+  `(selfcall
+    (return (& ,x ,y))))
 
 (defun comparison-conjuntion (vars op)
   (cond

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1127,6 +1127,13 @@
   `(selfcall
     (return (& ,x ,y))))
 
+;;; not canonical
+;;; binary-op restricted implementation
+(define-builtin logxor (x y)
+  `(selfcall
+    (return (^ ,x ,y))))
+
+
 (defun comparison-conjuntion (vars op)
   (cond
     ((null (cdr vars))

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -126,7 +126,7 @@
 (defun gcd-2 (a b)
   (if (zerop b)
       (abs a)
-    (gcd-2 b (mod a b))))
+    (gcd-2 b (rem a b))))
 
 (defun gcd (&rest integers)
   (cond ((null integers)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -88,7 +88,7 @@ accumulated, in the order."
 
 (defun list-to-vector (list)
   (let ((v (make-array (length list)))
-	(i 0))
+	      (i 0))
     (dolist (x list v)
       (aset v i x)
       (incf i))))
@@ -106,10 +106,10 @@ accumulated, in the order."
     (t
      (let ((digits nil))
        (while (not (zerop x))
-         (push (mod x 10) digits)
+         (push (rem x 10) digits)
          (setq x (truncate x 10)))
        (mapconcat (lambda (x) (string (digit-char x)))
-		  digits)))))
+		              digits)))))
 
 (defun float-to-string (x)
   #+jscl (float-to-string x)

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -195,4 +195,13 @@
         (= #x3FFFC
            (ash #xFFFF 2))))
 
+;;; test LOGNOT
+(test
+ (equal '(-1 -2 0 999)
+        (mapcar (lambda (x) (lognot x))
+                (list 0 1 -1 (1+ (lognot 1000))))))
+
+
+
+
 ;;; end

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -179,5 +179,20 @@
  (equal t
         (numberp (parse-integer (format nil "~d" (expt 10 65))))))
 
+;;; test ASH 
+;;; important note:
+;;; at clhs example (ash  -100000000000000000000000000000000 -100) => -79
+;;; but js op: -100000000000000000000000000000000 >> -100 => 0
+;;;
+(test
+ (equal '(32 16 8 0)
+        (mapcar (lambda (x y) (ash x y))
+                '(16 16 16 -100000000000000000000000000000000)
+                '(1 0 -1 -100))))
+
+(test
+ (equal t
+        (= #x3FFFC
+           (ash #xFFFF 2))))
 
 ;;; end

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -205,4 +205,11 @@
 (test (equal t (= 16 (logand 16 31))))
 
 
+;;; clhs (logxor 1 3 7 15) => 10
+(test
+ (equal t
+        (= 10
+           (logxor (logxor (logxor 1 3) 7) 15))))
+
+
 ;;; end

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -170,5 +170,14 @@
        (match (list T T T T T T T T T T)))
  (test (equal  pattern match)))
 
+;;; test what (expt 10 65) corrected parsed from string
+;;; Important note:
+;;;     sbcl: (expt 10 65) => 100000000000000000000000000000000000000000000000000000000000000000
+;;;     jscl: (expt 10 65) => 100000000000000000000008244226848602684002400884060400424240244468
+;;;
+(test
+ (equal t
+        (numberp (parse-integer (format nil "~d" (expt 10 65))))))
+
 
 ;;; end

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -201,7 +201,8 @@
         (mapcar (lambda (x) (lognot x))
                 (list 0 1 -1 (1+ (lognot 1000))))))
 
-
+;;; test LOGAND
+(test (equal t (= 16 (logand 16 31))))
 
 
 ;;; end


### PR DESCRIPTION
1. **utils.lisp**
Fixed `integer-to-string` for corrected parse `bignumber`. Current function with `mod`, parsed `(expt 10 65)` as: 
```lisp
CL-USER> (expt 10 65)
10000000000000000000000NIL00000000000000000000000000000000000000NIL000
CL-USER>  
```
Path fixed it. Now `(expt 10 65)` parsed as
```lisp
CL-USER> (expt 10 65)
100000000000000000000008244226848602684002400884060400424240244468
```

2. **codegenerator.lisp**
Fixed incorrect binary-op string for compilation **ASH** function (shift right)

3. **compiler.lisp**
Added implementation of the next standard functions: **ASH, LOGAND, LOGXOR, LOGNOT**. 
Function **LOGIOR** not released. The reason for this, is the birth trauma of the `reader`; it incorrectly reads the symbol `|` at compilation. There are no ideas how to fix it, and whether it is necessary to fix it. Maybe later, somehow...

4. Test cases added.


