### PR TITLE
Issue #378

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jscl",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A Common Lisp implementation for Javascript",
   "main": "jscl.js",
   "files": [

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1113,50 +1113,28 @@
         (throw "Division by zero"))
     (return (% ,x ,y))))
 
-
-#+nil
-(define-builtin ash (x y)
-  `(selfcall
-    (if (>= ,y 0)
-        (return (<< ,x ,y))
-        (return (>> ,x (- ,y))))))
-
+;;; @VKM path 30.11
 (define-builtin %ash-left (x y)
   `(call-internal |Bitwise_ash_L| ,x ,y))
 
 (define-builtin %ash-right (x y)
   `(call-internal |Bitwise_ash_R| ,x ,y))
 
-#+nil
-(define-builtin lognot (x)
-  `(selfcall
-    (return (~ ,x))))
-
 (define-builtin %lognot (x)
   `(call-internal |Bitwise_not| ,x ))
-
-#+nil
-(define-builtin logand (x y)
-  `(selfcall
-    (return (& ,x ,y))))
 
 (define-builtin %logand (x y)
   `(call-internal |Bitwise_and| ,x ,y))
 
 ;;; not canonical
 ;;; binary-op restricted implementation
-#+nil
-(define-builtin logxor (x y)
-  `(selfcall
-    (return (^ ,x ,y))))
-
 (define-builtin %logxor (x y)
   `(call-internal |Bitwise_xor| ,x ,y))
 
 ;;; logior
 (define-builtin %logior (x y)
   `(call-internal |Bitwise_ior| ,x ,y))
-
+;;; @vkm path 30.11 end
 
 (defun comparison-conjuntion (vars op)
   (cond

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1153,6 +1153,10 @@
 (define-builtin %logxor (x y)
   `(call-internal |Bitwise_xor| ,x ,y))
 
+;;; logior
+(define-builtin %logior (x y)
+  `(call-internal |Bitwise_ior| ,x ,y))
+
 
 (defun comparison-conjuntion (vars op)
   (cond

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1114,25 +1114,44 @@
     (return (% ,x ,y))))
 
 
+#+nil
 (define-builtin ash (x y)
   `(selfcall
     (if (>= ,y 0)
         (return (<< ,x ,y))
         (return (>> ,x (- ,y))))))
 
+(define-builtin %ash-left (x y)
+  `(call-internal |Bitwise_ash_L| ,x ,y))
+
+(define-builtin %ash-right (x y)
+  `(call-internal |Bitwise_ash_R| ,x ,y))
+
+#+nil
 (define-builtin lognot (x)
   `(selfcall
     (return (~ ,x))))
 
+(define-builtin %lognot (x)
+  `(call-internal |Bitwise_not| ,x ))
+
+#+nil
 (define-builtin logand (x y)
   `(selfcall
     (return (& ,x ,y))))
 
+(define-builtin %logand (x y)
+  `(call-internal |Bitwise_and| ,x ,y))
+
 ;;; not canonical
 ;;; binary-op restricted implementation
+#+nil
 (define-builtin logxor (x y)
   `(selfcall
     (return (^ ,x ,y))))
+
+(define-builtin %logxor (x y)
+  `(call-internal |Bitwise_xor| ,x ,y))
 
 
 (defun comparison-conjuntion (vars op)

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1162,6 +1162,10 @@
 (define-builtin numberp (x)
   (convert-to-bool `(== (typeof ,x) "number")))
 
+;;; @VKM PATH 30.11
+(define-builtin %truncate (x)
+`(method-call |Math| "trunc" ,x))
+
 (define-builtin %floor (x)
   `(method-call |Math| "floor" ,x))
 

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -348,5 +348,14 @@
 (defun mask-field (byte integer)
   (%logand integer (ash (1- (ash 1 (car byte))) (cdr byte))))
 
+;;; LDB
+;;; extract the specified byte from integer
+;;; result right justify
+(defun %ldb (size pos integer)
+  (%logand (ash integer (- pos))
+          (1- (ash 1 size))))
+
+(defun ldb (byte integer)
+  (%ldb (car byte) (cdr byte) integer))
 
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -374,4 +374,15 @@
 (defun dpb (newbyte byte integer)
   (%dpb newbyte (car byte) (cdr byte) integer))
 
+;;; DEPOSIT-FIELD
+;;; return new integer with newbyte in specified position
+;;; newbyte isnt right justify
+(defun %deposit-field (newbyte size posn integer)
+  (let ((mask (ash (%ldb size 0 -1) posn)))
+    (%logior (%logand newbyte mask)
+            (%logand integer (%lognot mask)))))
+
+(defun deposit-field (newbyte byte integer)
+  (%deposit-field newbyte (car byte) (cdr byte) integer))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -228,9 +228,8 @@
             ((endp integers)  result)))))
 
 ;;; integer-length
-;;; ONLY 32 bits
-;;; note: its very simple and incorrect function compiled from
-;;; originaled sbcl.
+;;; note: ONLY 32 bits
+;;; note: its very simple and incorrect function
 ;;; todo: We need version with corrected doing fixnum & bignum numbers
 (defun integer-length (integer)
   (let ((negative (minusp integer)))
@@ -238,7 +237,7 @@
       (setq integer (- integer)))
     (if (> integer most-integer-length)
         ;; prevent infinity loop with (integer-length (expt 2 31))
-        (error "integer-length: bad numeric limit ~" integer)) 
+        (error "integer-length: bad numeric limit ~a" integer)) 
     (do ((len 0 (1+ len))
          (original integer))
         ((zerop integer)
@@ -262,6 +261,9 @@
       (minusp integer)))
 
 ;;; LOGCOUNT
+;;; note: ONLY 32 bits
+;;; note: its very simple and incorrect function
+;;; todo: We need version with corrected doing fixnum & bignum numbers
 ;;; Count the number of 1 bits if INTEGER is non-negative,
 ;;; and the number of 0 bits if INTEGER is negative
 (defun %logcount (integer)

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -363,4 +363,15 @@
 (defun ldb-test (byte number)
   (not (zerop (ldb byte number))))
 
+;;; DPB
+;;; return new integer with newbyte in specified position
+;;; newbyte is right justify
+(defun %dpb (newbyte size posn integer)
+  (let ((mask (1- (ash 1 size))))
+    (%logior (%logand integer (%lognot (ash mask posn)))
+            (ash (%logand newbyte mask) posn))))
+
+(defun dpb (newbyte byte integer)
+  (%dpb newbyte (car byte) (cdr byte) integer))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -242,4 +242,9 @@
              len))
       (setq integer (ash integer -1)))))
 
+;;; logtest
+;;; Return T if logand of integer1 and integer2 is not zero
+(defun logtest (integer1 integer2)
+  (not (zerop (%logand integer1 integer2))))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -266,4 +266,21 @@
 (defun logcount (integer)
   (%logcount (if (minusp integer) (%lognot integer) integer)))
 
+(defconstant boole-1     0)    ;; integer-1                                   
+(defconstant boole-2     1)    ;; integer-2                                   
+(defconstant boole-andc1 2)    ;; and complement of integer-1 with integer-2  
+(defconstant boole-andc2 3)    ;; and integer-1 with complement of integer-2  
+(defconstant boole-and   4)    ;; and                                         
+(defconstant boole-c1    5)    ;; complement of integer-1                     
+(defconstant boole-c2    6)    ;; complement of integer-2                     
+(defconstant boole-clr   7)    ;; always 0 (all zero bits)                    
+(defconstant boole-eqv   8)    ;; equivalence (exclusive nor)                 
+(defconstant boole-ior   9)    ;; inclusive or                                
+(defconstant boole-nand  10)   ;; not-and                                     
+(defconstant boole-nor   11)   ;; not-or                                      
+(defconstant boole-orc1  12)   ;; or complement of integer-1 with integer-2   
+(defconstant boole-orc2  13)   ;; or integer-1 with complement of integer-2   
+(defconstant boole-set   14)   ;; always -1 (all one bits)                    
+(defconstant boole-xor   15)   ;; exclusive or                                
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -332,4 +332,11 @@
 (defun byte-position (spec)
   (cdr spec))
 
+;;; CLZ32
+;;; count leading zero
+;;; ONLY 32 bits
+(defun clz32 (number)
+  (#j:Math:clz32 number))
+
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -191,4 +191,11 @@
 ;;; lognot
 (defun lognot (x) (%lognot x))
 
+;;; logxor
+(defun logxor (integer &rest others)
+  (do ((integers others (cdr integers))
+       (result integer (%logxor result (car integers))))
+      ((endp integers)  result)
+   0))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -291,4 +291,27 @@
 (defun logiorc1  (x y)  (%logior  (%lognot x) y))
 (defun logiorc2  (x y)  (%logior x (%lognot y)))
 
+;;; BOOLE
+(defun boole (op i1 i2)
+    (cond
+      ((eq op boole-clr)      0)
+      ((eq op boole-set)     -1)
+      ((eq op boole-1)              i1)
+      ((eq op boole-2)          i2)
+      ((eq op boole-c1)    (%lognot i1))
+      ((eq op boole-c2)    (%lognot i2))
+      ((eq op boole-and)   (%logand i1 i2))
+      ((eq op boole-ior)   (%logior i1 i2))
+      ((eq op boole-xor)   (%logxor i1 i2))
+      ((eq op boole-eqv)   (%logeqv i1 i2))
+      ((eq op boole-nand)  (%lognot (%logand i1 i2)))
+      ((eq op boole-nor)   (%lognot (%logior i1 i2)))
+      ((eq op boole-andc1) (%logand (%lognot i1) i2))
+      ((eq op boole-andc2) (%logand i1 (%lognot i2)))
+      ((eq op boole-orc1)  (%logior (%lognot i1) i2))
+      ((eq op boole-orc2)  (%logior i1 (%lognot i2)))
+      (t (error "~S is an illegal control code to BOOLE." op))))
+
+
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -157,6 +157,8 @@
 	(t
 	 (apply #'lcm (lcm (first integers) (second integers)) (nthcdr 2 integers)))))
 
+;;; @VKM path 30.11
+
 ;;; round number/division to nearest integer
 ;;; second value is remainder
 (defun round (number &optional (divisor 1))
@@ -177,7 +179,6 @@
                      (values (- integer 1) (+ remainder divisor))))
                 (t (values integer remainder)))))))
 
-;;; @VKM path 30.11
 (defconstant most-integer-length (expt 2 30))
 
 ;;; ash
@@ -214,5 +215,13 @@
         (do ((integers (cdr others) (cdr integers))
              (result integer (%logeqv result (car integers))))
             ((endp integers)  result)))))
+
+;;; logior
+(defun logior (integer &rest others)
+  (do ((integers others (cdr integers))
+       (result integer (%logior result (car integers))))
+      ((endp integers)  result)
+   0))
+
 
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -247,4 +247,10 @@
 (defun logtest (integer1 integer2)
   (not (zerop (%logand integer1 integer2))))
 
+;;; logbitp
+(defun logbitp (index integer)
+  (if (< index most-positive-fixnum)
+      (not (zerop (%logand integer (ash 1 index))))
+      (minusp integer)))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -194,7 +194,7 @@
 (defun lognot (x) (%lognot x))
 
 ;;; logxor
-(defun logxor (integer &rest others)
+(defun logxor (&rest others)
   (if (null others) (return-from logxor 0)
       (let ((integer (car others)))
         (do ((integers others (cdr integers))

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -198,4 +198,11 @@
       ((endp integers)  result)
    0))
 
+;;; logand
+(defun logand (integer &rest others)
+  (do ((integers others (cdr integers))
+       (result integer (%Logand result (car integers))))
+      ((endp integers)  result)
+   -1))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -317,4 +317,19 @@
   (let ((rn (#j:Math:random n)))
     (#j:Math:floor (* rn n))))
 
+;;; BYTE
+;;; return  byte specifier
+(defun byte (size position)
+  (cons size position))
+
+;;; BYTE-SIZE
+;;; return the size part of the byte specifier
+(defun byte-size (spec)
+  (car spec))
+
+;;; BYTE-POSITION
+;;; return thhe position part of the byte specifier
+(defun byte-position (spec)
+  (cdr spec))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -338,5 +338,15 @@
 (defun clz32 (number)
   (#j:Math:clz32 number))
 
+;;; MASK-FIELD
+;;; extract the specified byte from integer
+;;; result not right justify
+(defun %mask-field (size posn integer)
+  (%logand integer (ash (1- (ash 1 size)) posn)))
+
+;;; todo: (setf)
+(defun mask-field (byte integer)
+  (%logand integer (ash (1- (ash 1 (car byte))) (cdr byte))))
+
 
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -78,6 +78,7 @@
 (defun truncate (number &optional (divisor 1))
   (let ((res (%truncate (/ number divisor))))
     (values res (- number (* res divisor)))))
+;;; @vkm 30.11 end
 
 (defun integerp (x)
   (and (numberp x) (= (floor x) x)))
@@ -384,5 +385,7 @@
 
 (defun deposit-field (newbyte byte integer)
   (%deposit-field newbyte (car byte) (cdr byte) integer))
+
+;;; @vkm 30.11 end
 
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -223,5 +223,23 @@
       ((endp integers)  result)
    0))
 
+;;; integer-length
+;;; ONLY 32 bits
+(defun integer-length (integer)
+  (let ((negative (minusp integer)))
+    (if negative
+      (setq integer (- integer)))
+    (if (> integer most-integer-length)
+        (error "integer-length: bad numeric limit ~" integer)) 
+    (do ((len 0 (1+ len))
+         (original integer))
+        ((zerop integer)
+         ;; Negative powers of two require one less bit.
+         (if (and negative
+                  ;; Test if original is power-of-two.
+                  (zerop (%logand original (1- original))))
+             (1- len)
+             len))
+      (setq integer (ash integer -1)))))
 
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -188,5 +188,7 @@
         (%ash-right x y)
         (%ash-left x  y))))
 
+;;; lognot
+(defun lognot (x) (%lognot x))
 
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -253,4 +253,17 @@
       (not (zerop (%logand integer (ash 1 index))))
       (minusp integer)))
 
+;;; LOGCOUNT
+;;; Count the number of 1 bits if INTEGER is non-negative,
+;;; and the number of 0 bits if INTEGER is negative
+(defun %logcount (integer)
+  (let ((length (integer-length integer))
+        (result 0))
+    (dotimes (bit length)
+      (if (logbitp bit integer) (incf result)))
+    result))
+
+(defun logcount (integer)
+  (%logcount (if (minusp integer) (%lognot integer) integer)))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -205,4 +205,14 @@
       ((endp integers)  result)
    -1))
 
+;;; logeqv
+(defun %logeqv (x y) (%lognot (%logxor x y)))
+
+(defun logeqv (&rest others)
+  (if (null others) (return-from logeqv -1)
+      (let ((integer (car others)))
+        (do ((integers (cdr others) (cdr integers))
+             (result integer (%logeqv result (car integers))))
+            ((endp integers)  result)))))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -312,6 +312,9 @@
       ((eq op boole-orc2)  (%logior i1 (%lognot i2)))
       (t (error "~S is an illegal control code to BOOLE." op))))
 
-
+;;; RANDOM
+(defun random (n)
+  (let ((rn (#j:Math:random n)))
+    (#j:Math:floor (* rn n))))
 
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -283,4 +283,12 @@
 (defconstant boole-set   14)   ;; always -1 (all one bits)                    
 (defconstant boole-xor   15)   ;; exclusive or                                
 
+;;; fns definition: lognand, lognor, logandc*, logorc*
+(defun lognand  (x y)  (%lognot (%logand x y)))
+(defun lognor   (x y)  (%lognot (%logior x y)))
+(defun logandc1 (x y)  (%logand (%lognot x) y))
+(defun logandc2 (x y)  (%logand x (%lognot y)))
+(defun logiorc1  (x y)  (%logior  (%lognot x) y))
+(defun logiorc2  (x y)  (%logior x (%lognot y)))
+
 ;;; EOF

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -196,9 +196,9 @@
 ;;; logxor
 (defun logxor (&rest others)
   (if (null others) (return-from logxor 0)
-      (let ((integer (car others)))
+      (let ((result (car others)))
         (do ((integers others (cdr integers))
-             (result integer (%logxor result (car integers))))
+             (result 0 (%logxor result (car integers))))
             ((endp integers)  result)))))
 
 ;;; logand

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -195,17 +195,19 @@
 
 ;;; logxor
 (defun logxor (integer &rest others)
-  (do ((integers others (cdr integers))
-       (result integer (%logxor result (car integers))))
-      ((endp integers)  result)
-   0))
+  (if (null others) (return-from logxor 0)
+      (let ((integer (car others)))
+        (do ((integers others (cdr integers))
+             (result integer (%logxor result (car integers))))
+            ((endp integers)  result)))))
 
 ;;; logand
-(defun logand (integer &rest others)
-  (do ((integers others (cdr integers))
-       (result integer (%Logand result (car integers))))
-      ((endp integers)  result)
-   -1))
+(defun logand (&rest others)
+  (if (null others) (return-from logand -1)
+      (let ((integer (car others)))
+        (do ((integers others (cdr integers))
+             (result integer (%Logand result (car integers))))
+            ((endp integers)  result)))))
 
 ;;; logeqv
 (defun %logeqv (x y) (%lognot (%logxor x y)))
@@ -218,19 +220,24 @@
             ((endp integers)  result)))))
 
 ;;; logior
-(defun logior (integer &rest others)
-  (do ((integers others (cdr integers))
-       (result integer (%logior result (car integers))))
-      ((endp integers)  result)
-   0))
+(defun logior (&rest others)
+  (if (null others) (return-from logior 0)
+      (let ((integer (car others)))
+        (do ((integers others (cdr integers))
+             (result integer (%logior result (car integers))))
+            ((endp integers)  result)))))
 
 ;;; integer-length
 ;;; ONLY 32 bits
+;;; note: its very simple and incorrect function compiled from
+;;; originaled sbcl.
+;;; todo: We need version with corrected doing fixnum & bignum numbers
 (defun integer-length (integer)
   (let ((negative (minusp integer)))
     (if negative
       (setq integer (- integer)))
     (if (> integer most-integer-length)
+        ;; prevent infinity loop with (integer-length (expt 2 31))
         (error "integer-length: bad numeric limit ~" integer)) 
     (do ((len 0 (1+ len))
          (original integer))

--- a/src/numbers.lisp
+++ b/src/numbers.lisp
@@ -358,4 +358,9 @@
 (defun ldb (byte integer)
   (%ldb (car byte) (cdr byte) integer))
 
+;;; LDB-TEST
+;;; todo: (setf)
+(defun ldb-test (byte number)
+  (not (zerop (ldb byte number))))
+
 ;;; EOF

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -82,6 +82,19 @@ var reqXHRsendNull = function(req){
   req.send(null);
 };
 
+// Workaround the problem with operator precedence
+// ash
+internals.Bitwise_ash_R = function (x, y) { return x >> y;};
+internals.Bitwise_ash_L = function (x, y) { return x << y;};
+// lognot
+internals.Bitwise_not = function (x) {return ~x;};
+// logior
+internals.Bitwise_ior = function (x, y) {return x | y;};
+// logxor
+internals.Bitwise_xor = function (x, y) {return x ^ y;};
+// logand
+internals.Bitwise_and = function (x, y) { return x & y;};
+
 
 // NOTE: Define VALUES to be MV for toplevel forms. It is because
 // `eval' compiles the forms and execute the Javascript code at

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -77,7 +77,8 @@ internals.newInstance = function(values, ct){
   return new newCt();
 };
 
-// Workaround the problem with send NULL for async XHR 
+// Workaround the problem with send NULL for async XHR
+// BUG: future todo
 var reqXHRsendNull = function(req){
   req.send(null);
 };

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -221,15 +221,26 @@
  (eq 10 (logxor 1 3 7 15)))
 
 (test
-(let ((result))
+ (let ((pattern '(list -1 -1 0  0 -1 -2 0 999)))
+   (equal pattern
+          (list (logand) ;; must be -1
+                (logeqv) ;; must be -1
+                (logior) ;; must be 0
+                (logxor) ;; must be 0
+                (lognot 0)
+                (lognot 1)
+                (lognot -1)
+                (lognot (1+ (lognot 1000)))))))
+
+(test
+ (let ((result))
    (dolist (symbol '(boole-1     boole-2    boole-and  boole-andc1
                      boole-andc2 boole-c1   boole-c2   boole-clr
                      boole-eqv   boole-ior  boole-nand boole-nor
                      boole-orc1  boole-orc2 boole-set  boole-xor))
      (push (boole (symbol-value symbol) #b0011 #b0101) result))
-     (equal '(3 5 1 4 2 -4 -6 0 -7 7 -2 -8 -3 -5 -1 6)
-            (reverse result)))
-)
+   (equal '(3 5 1 4 2 -4 -6 0 -7 7 -2 -8 -3 -5 -1 6)
+          (reverse result))))
 
 (defconstant boole-n-vector
   (vector boole-clr   boole-and  boole-andc1 boole-2

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -227,7 +227,7 @@
  (eq 10 (logxor 1 3 7 15)))
 
 (test
- (let ((pattern '(list -1 -1 0  0 -1 -2 0 999)))
+ (let ((pattern '(-1 -1 0 0 -1 -2 0 999)))
    (equal pattern
           (list (logand) ;; must be -1
                 (logeqv) ;; must be -1

--- a/tests/numbers.lisp
+++ b/tests/numbers.lisp
@@ -185,10 +185,16 @@
 ;;; but js op: -100000000000000000000000000000000 >> -100 => 0
 ;;;
 (test
- (equal '(32 16 8 0)
-        (mapcar (lambda (x y) (ash x y))
-                '(16 16 16 -100000000000000000000000000000000)
-                '(1 0 -1 -100))))
+ (let ((pattern '(32 16 8 0))
+       (result  (mapcar (lambda (x y) (ash x y))
+                        '(16 16 16 -100000000000000000000000000000000)
+                        '(1 0 -1 -100))))
+   (equal pattern result)))
+
+;;;(equal '(32 16 8 0)
+;;;        (mapcar (lambda (x y) (ash x y))
+;;;                '(16 16 16 -100000000000000000000000000000000)
+;;;                '(1 0 -1 -100))))
 
 (test
  (equal t
@@ -211,5 +217,112 @@
         (= 10
            (logxor (logxor (logxor 1 3) 7) 15))))
 
+(test
+ (eq 10 (logxor 1 3 7 15)))
+
+(test
+(let ((result))
+   (dolist (symbol '(boole-1     boole-2    boole-and  boole-andc1
+                     boole-andc2 boole-c1   boole-c2   boole-clr
+                     boole-eqv   boole-ior  boole-nand boole-nor
+                     boole-orc1  boole-orc2 boole-set  boole-xor))
+     (push (boole (symbol-value symbol) #b0011 #b0101) result))
+     (equal '(3 5 1 4 2 -4 -6 0 -7 7 -2 -8 -3 -5 -1 6)
+            (reverse result)))
+)
+
+(defconstant boole-n-vector
+  (vector boole-clr   boole-and  boole-andc1 boole-2
+          boole-andc2 boole-1    boole-xor   boole-ior
+          boole-nor   boole-eqv  boole-c1    boole-orc1
+          boole-c2    boole-orc2 boole-nand  boole-set))
+
+(defun boole-n (n integer &rest more-integers)
+  (apply #'boole (elt boole-n-vector n) integer more-integers))
+
+(test
+ (let ((pattern '(0 1 2 3 4 5 6 7 -8 -7 -6 -5 -4 -3 -2 -1))
+       (result (loop for n from #b0000 to #b1111 collect (boole-n n 5 3))))
+   (equal pattern result)))
+
+;;; 
+(test (let ((n1 1) (n2 2)) (eq (lognand n1 n2) (lognot (logand n1 n2)))))
+(test (let ((n1 1) (n2 2)) (eq (lognor n1 n2) (lognot (logior n1 n2)))))
+(test (let ((n1 1) (n2 2)) (eq (logandc1 n1 n2) (logand (lognot n1)  n2))))
+(test (let ((n1 1) (n2 2)) (eq (logandc2 n1 n2) (logand n1 (lognot n2)))))
+(test (let ((n1 1) (n2 2)) (eq (logiorc1 n1 n2) (logior (lognot n1) n2))))
+(test (let ((n1 1) (n2 2)) (eq (logiorc2 n1 n2) (logior n1 (lognot n2)))))
+(test (let ((j 1) (x 2))   (eq (logbitp j (lognot x)) (not (logbitp j x)))))
+
+(test
+ (let ((pattern '(nil t t t t nil))
+       (result (list (logbitp 1 1) (logbitp 0 1) (logbitp 3 10)
+                     (logbitp 1000000 -1) (logbitp 2 6) (logbitp 0 6))))
+   (equal pattern result)))
+
+(test
+ (let ((k 2) (n 6))
+  (eql (logbitp k n) (ldb-test (byte 1 k) n))))
+
+;;; LOGCOUNT
+(test
+ (let* ((x 123)
+        (r (logcount x)))
+   (eql (eql r (logcount (- (+ x 1))))
+        (eql r (logcount (lognot x))))))
+
+(defun identity-logcount (n)
+  (let* ((x n)
+         (r (logcount x)))
+    (eql (eql r (logcount (- (+ x 1))))
+         (eql r (logcount (lognot x))))))
+
+(test
+ (equal '(t)
+        (remove-duplicates
+         (jscl::with-collect
+           (dotimes (i 100)
+             (jscl::collect (identity-logcount (random 100))))))))
+
+;;; BYTE
+(test
+ (let ((j 1) (k 2))
+   (and
+    (eq (byte-size (byte j k)) j)
+    (eq (byte-position (byte j k)) k))))
+
+;;; LOGTEST
+(test
+  (let ((pattern '(t nil t nil))
+      (result (list  (logtest 1 7) (logtest 1 2)
+                     (logtest -2 -1) (logtest 0 -1))))
+  (equal pattern result)))
+
+;;; test identity
+(test
+ (let ((x 1) (y 7))
+  (eq (logtest x y) (not (zerop (logand x y))))))
+
+;;; DEPOSIT-FIELD
+(test
+ (let ((pattern '(6 15 -7))
+       (result
+         (list
+          (deposit-field 7 (byte 2 1) 0)
+          (deposit-field -1 (byte 4 0) 0)
+          (deposit-field 0 (byte 2 1) -3))))
+   (equal pattern result)))
+
+;;; DPB
+(test
+ (let ((pattern '(1024 2048 1024))
+       (result
+         (list (dpb 1 (byte 1 10) 0)
+               (dpb -2 (byte 2 10) 0)
+               (dpb 1 (byte 2 10) 2048))))
+   (equal pattern result)))
+
+;;; LDB
+(test (eq 1 (ldb (byte 2 1) 10) ))
 
 ;;; end


### PR DESCRIPTION
Added logical bitwise functions for `32bits` numbers:
- boole
- byte, byte-size, byte-position
- ldb, dpb,
- deposit-field, mask-field
- logior, logbitp
- integer-length
- round, random
- clz32
- logtest, logcount`
- lognand, logandc1, logandc2, logiorc1, logiorc2
- replace truncate fucntion: the function should return (values ...)

