### PR TITLE
Show correct package in nodejs prompt

### DIFF
--- a/node/node.lisp
+++ b/node/node.lisp
@@ -19,7 +19,7 @@
   (welcome-message)
   (setq *rl* (#j:readline:createInterface #j:process:stdin #j:process:stdout))
   (let ((*root* *rl*))
-    (#j:setPrompt "CL-USER> ")
+    (#j:setPrompt (format nil "~a> " (package-name *package*)))
     (#j:prompt)
     (#j:on "line"
            (lambda (line)
@@ -37,6 +37,9 @@
               (catch (err)
                 (let ((message (or (oget err "message") err)))
                   (format t "ERROR[!]: ~a~%" message))))
+             ;; Update prompt
+             (let ((*root* *rl*))
+               (#j:setPrompt (format nil "~a> " (package-name *package*))))
              ;; Continue
              ((oget *rl* "prompt"))))))
 


### PR DESCRIPTION
This fixes the nodejs prompt package prefix.

With this patch:

```
$ node jscl-node-wrapper.js
...
CL-USER> *package*
#<PACKAGE CL-USER>
CL-USER> (defpackage jscl-user (:use cl jscl))
NIL
CL-USER> (in-package :jscl-user)
#<PACKAGE JSCL-USER>
JSCL-USER> *package*
#<PACKAGE JSCL-USER>
JSCL-USER>
```

Without this patch:

```
$ node jscl-node-wrapper.js
...
CL-USER> *package*
#<PACKAGE CL-USER>
CL-USER> (defpackage jscl-user (:use cl jscl))
NIL
CL-USER> (in-package :jscl-user)
#<PACKAGE JSCL-USER>
CL-USER> *package*
#<PACKAGE JSCL-USER>
CL-USER>
```