### PR TITLE
Readable printing of structs

### DIFF
--- a/src/clos/mop-utils.lisp
+++ b/src/clos/mop-utils.lisp
@@ -42,6 +42,19 @@
           " "
           (string (mop-class-name (mop-class-of (mop-class-of place)))) ))
 
+(defun mop-object-struct-slots (form)
+  (let* ((slots (slot-value (mop-class-of form) 'direct-slots))
+       (slot-values (std-instance-slots form))
+       (num-slots (length slots))
+       (result ""))
+    (dotimes (idx num-slots result)
+      (setq result (concat result ":" ))
+      (setq result (concat result (getf (nth idx slots) :name)))
+      (setq result (concat result " " ))
+      (setq result (concat result (write-to-string (aref slot-values idx))))
+      (when (<= idx (- num-slots 2))      ; dont print final space
+        (setq result (concat result " " ))))))
+
 ;;; mop object printer
 (defun mop-object-printer (form stream)
   (let ((res (case (mop-class-name (mop-class-of form))
@@ -53,8 +66,13 @@
                 (concat "#<standard-method " (write-to-string (generic-function-name (method-generic-function form)))
                         (write-to-string (generate-specialized-arglist form)) ">"))
                (otherwise
-                (concat "#<instance " (write-to-string (mop-class-name (mop-class-of form))) " "
-                        (mop-object-slots (std-instance-slots form)) ">")))))
+                 (case (mop-class-name (mop-class-of (mop-class-of form)))
+                   (structure-class (concat "#S("
+                                      (write-to-string (mop-class-name (mop-class-of form)))
+                                      " " (mop-object-struct-slots form) ")"))
+                   (otherwise
+                     (concat "#<instance " (write-to-string (mop-class-name (mop-class-of form))) " "
+                       (mop-object-slots (std-instance-slots form)) ">")))))))
     (simple-format stream res)))
 
 

--- a/tests/defstruct.lisp
+++ b/tests/defstruct.lisp
@@ -546,4 +546,16 @@
         (conc-name-nil-slot (make-conc-name-nil))
       (error (c) nil)))))
 
+(defstruct print-struct-test a b c)
+(test
+  ;; struct printing with only numbers
+  (string-equal
+    (format nil "~S" (make-print-struct-test :a 1 :b 2 :c 3))
+    "#S(JSCL::PRINT-STRUCT-TEST :A 1 :B 2 :C 3)"))
+(test
+  ;; struct printing with some strings in it
+  (string-equal
+    (format nil "~S" (make-print-struct-test :a "hello" :b "world" :c 3))
+    "#S(JSCL::PRINT-STRUCT-TEST :A \"hello\" :B \"world\" :C 3)"))
+
 ;;; EOF


### PR DESCRIPTION
This change prints structs created with `defstruct` in a readble format.

Instead of printing `#<instance STRUCTURE-CLASS FOO ...>`, we print
`#S(FOO ...)`. This allows a parser to reinstantiate this structure from
a string.

Sharpsign S: http://clhs.lisp.se/Body/02_dhm.htm
Printing Structures: http://clhs.lisp.se/Body/22_acl.htm