### PR TITLE
Make hash-table support numbers as keys

### DIFF
--- a/src/prelude.js
+++ b/src/prelude.js
@@ -224,6 +224,7 @@ internals.safe_char_downcase = function(x) {
 };
 
 internals.xstring = function(x){
+  if(typeof x === "number") return x.toString();
   const hasFillPointer = typeof x.fillpointer === 'number'
   const activechars = hasFillPointer? x.slice(0, x.fillpointer): x
   return activechars.join('');

--- a/tests/ffi.lisp
+++ b/tests/ffi.lisp
@@ -58,4 +58,11 @@
   (test (js-object-p obj))
   (test (js-object-signature obj)))
 
+;;; test in can handle numbers
+
+(let ((obj (make-new #j:Object)))
+  (test (js-object-p obj))
+  (test (oset 456 obj 123))
+  (test (equal 456 (oget obj 123))))
+
 ;;; EOF

--- a/tests/hash-tables.lisp
+++ b/tests/hash-tables.lisp
@@ -133,4 +133,19 @@
                 (let ((h (temp-hash-table :fill t)))
                   (remhash 'one h)
                   h))))
+
+;;; Test numbers as keys
+(let ((ht (make-hash-table)))
+  (test (eq nil (gethash 123 ht)))
+  (test (eq 'foo (setf (gethash 123 ht) 'foo)))
+  (test (eq 'foo (gethash 123 ht))))
+
+;;; Test numbers are different than strings
+(let ((ht (make-hash-table :test #'equal)))
+  (test (equal 'foo (setf (gethash 123 ht) 'foo)))
+  (test (equal 'bar (setf (gethash "123" ht) 'bar)))
+  (test (equal 'foo (gethash 123 ht)))
+  (test (equal 'bar (gethash "123" ht)))
+  (test (eq 2 (length (hash-table-keys ht)))))
+
 ;;; EOF


### PR DESCRIPTION
This allows numbers to be used as hash-table keys, since they are crudely converted to strings.

Closes #424