### PR TITLE
Ensure unboundFunction is bound to the right symbol

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -156,7 +156,9 @@
   (boundp x))
 
 (defun fboundp (x)
-  (fboundp x))
+  (if (functionp x)
+      (error "FBOUNDP - invalid function name ~a." x))
+  (%fboundp x))
 
 (defun eq (x y) (eq x y))
 (defun eql (x y) (eq x y))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1221,7 +1221,7 @@
   (convert-to-bool `(!== (get ,x "value") undefined)))
 
 (define-builtin fboundp (x)
-  (convert-to-bool `(!== (get ,x "fvalue") (internal |unboundFunction|))))
+  (convert-to-bool `(call-internal |fboundp| ,x)))
 
 (define-builtin symbol-value (x)
   `(call-internal |symbolValue| ,x))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1220,7 +1220,7 @@
 (define-builtin boundp (x)
   (convert-to-bool `(!== (get ,x "value") undefined)))
 
-(define-builtin fboundp (x)
+(define-builtin %fboundp (x)
   (convert-to-bool `(call-internal |fboundp| ,x)))
 
 (define-builtin symbol-value (x)

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -339,7 +339,7 @@ internals.Symbol = function(name, package_name){
   this.name = name;
   this.package = package_name;
   this.value = undefined;
-  this.fvalue = internals.unboundFunction;
+  this.fvalue = internals.unboundFunction.bind(this);
   this.stack = [];
 };
 

--- a/tests/defstruct.lisp
+++ b/tests/defstruct.lisp
@@ -113,7 +113,7 @@
 (test
  (mv-eql
   (values
-   (mapcar 'fboundp (list #'sbt-02-a #'sbt-02-p #'copy-sbt-02))
+   (mapcar 'fboundp (list 'sbt-02-a 'sbt-02-p 'copy-sbt-02))
    (sbt-02-con)
    (sbt-02-con :foo 99)
    (sbt-02-a (sbt-02-con :foo 1234)))

--- a/tests/variables.lisp
+++ b/tests/variables.lisp
@@ -22,4 +22,8 @@
   (let ((*special-defparameter* 2))
     (test (= (f) 2))))
 
+
+(test (not (fboundp 'abc)))
+
+
 ;;; EOF


### PR DESCRIPTION
That way the error messagae will be correct regardless if we invoke it
like symbol.fvalue() or if we assign it first into a variable, losing
the `this` context.

## Detailed

I started debugging #438, narrow it down to this simple issue:

```
(search "a" "b" :test 'equalp)
; ERROR: Cannot read properties of undefined (reading 'name')
```

It should be more intuitive than that error. Like the regular `equalp` is not bound.

Looking at the definition, and how it dispatches by sequence type, I tried with other couple of sequences:
https://github.com/jscl-project/jscl/blob/29885f79a236f71d38e1fe2ea73c3158a8324291/src/sequence.lisp#L353-L383

```
CL-USER> (search '(1) '(2) :test 'equalp)
ERROR: Cannot read properties of undefined (reading 'name')
CL-USER> (search #(1) #(2) :test 'equalp)
ERROR: Cannot read properties of undefined (reading 'name')
```

still happens.  So it seems that it migth be in the generic util `satisfies-test-p`, and indeed:

```
CL-USER> (in-package :jscl)
#<PACKAGE JSCL>
JSCL> (satisfies-test-p 1 2)
NIL
JSCL> (satisfies-test-p 1 2 :test 'equalp)
ERROR: Cannot read properties of undefined (reading 'name')
```

The only thing this does is [calling `funcall`](https://github.com/jscl-project/jscl/blob/29885f79a236f71d38e1fe2ea73c3158a8324291/src/utils.lisp#L123)

So we can simplify it even more to just `funcall`:

```
CL-USER> (funcall 'f)
ERROR: Cannot read properties of undefined (reading 'name')
```

At this point this is a primitive compilation defined in the compiler.  I did generate the code for that simple example with

```lisp
(jscl::with-compilation-environment
  (jscl::compile-toplevel '(funcall 'f)))
```

resulting in:

```javascript
var l1=internals.intern('F','CL-USER');
(function(){
  var F=l1;
  return (typeof F==='function'?F:F.fvalue)(internals.pv);
})();
```

Not a lot happening..  no mention of the `name`.  Except I noticed something.  `symbol.fvalue` is  initialized to `unboundFunction` in order to generate an error if a undefined function is called. Code code in prelude is

https://github.com/jscl-project/jscl/blob/29885f79a236f71d38e1fe2ea73c3158a8324291/src/prelude.js#L334-L336

This could explain.  If `unboundFunction`'s **this** is only defined if we call it like symb.fvalue.  If we get that value out into another expression and call it.  `this` will be undefined.

We can try that int he JS console:

```javascript
jscl.internals.intern('F').fvalue()
/*
jscl.js:337 Uncaught Error: Function 'F' undefined
    at internals.unboundFunction [as fvalue] (jscl.js:337:9)
    at <anonymous>:1:30
*/
```

that is correct. But if the compiler generates:

```javascript
(true? jscl.internals.intern('F').fvalue: null)()
/*
jscl.js:337 Uncaught TypeError: Cannot read properties of undefined (reading 'name')
    at internals.unboundFunction (jscl.js:337:39)
    at <anonymous>:1:48
internals.unboundFunction @ jscl.js:337
(anonymous) @ VM984:1
*/
```

Then we can reproduce the problem.

That is kind of what the compiler generates!

```
(typeof F==='function'?F:F.fvalue)(internals.pv);
```

Possible solutions for this would be:

- Not using `this` in `unboundSymbol`, [bind it](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind) it to the symbol when the symbol is `intern`ed
- Changing the generated code to make sure we call the function with the right `this` context associated.

We could generate fo rinstance
```
(typeof F==='function'?F:F.fvalue).call(F, internals.pv);
```

The `bind` method is more robust probably.
