### PR TITLE
Path 1120 2022

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -448,6 +448,12 @@
 
 (defparameter *features* '(:jscl :common-lisp))
 
+;;; @vlad-km 20112022
+;;; Enable/disable class redefinition mode. By default - disable
+;;;    (declaim (clos override))     -- enable class redefinition
+;;;    (declaim (clos non-override)) -- disable class redefinition
+(defparameter  *clos-override-mode* nil)
+
 ;;; symbol-function from compiler macro
 (defun functionp (f) (functionp f))
 

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -448,7 +448,6 @@
 
 (defparameter *features* '(:jscl :common-lisp))
 
-;;; @vlad-km 20112022
 ;;; Enable/disable class redefinition mode. By default - disable
 ;;;    (declaim (clos override))     -- enable class redefinition
 ;;;    (declaim (clos non-override)) -- disable class redefinition
@@ -464,14 +463,18 @@
   (%js-try
    (progn (oget object "dt_Name"))
     (catch (m) nil)))
+
 (defun set-object-type-code (object tag) (oset tag object "dt_Name"))
 
 ;;; types predicate's
-(defun mop-object-p (obj)
-  (and (consp obj)
-       (= (length obj) 5)
-       (eql (object-type-code obj) :mop-object)))
 
+;;; consp this is a common predicate for cons and list
+;;; mop predicate evaluates the length of the list, which causes
+;;; an interrupt for the cons cell
+(defun mop-object-p (obj)
+  ;; evaluated only `proper list` not `cons cell`
+  (and (proper-list-length-p obj 5 5)
+       (eql (object-type-code obj) :mop-object)))
 
 (defun clos-object-p (object) (eql (object-type-code object) :clos_object))
 

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -460,7 +460,10 @@
 ;;; types family section
 
 ;;; tag's utils
-(defun object-type-code (object) (oget object "dt_Name"))
+(defun object-type-code (object)
+  (%js-try
+   (progn (oget object "dt_Name"))
+    (catch (m) nil)))
 (defun set-object-type-code (object tag) (oset tag object "dt_Name"))
 
 ;;; types predicate's

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -468,9 +468,10 @@
 
 ;;; types predicate's
 (defun mop-object-p (obj)
-    (and (consp obj)
-         (eql (object-type-code obj) :mop-object)
-         (= (length obj) 5)))
+  (and (consp obj)
+       (= (length obj) 5)
+       (eql (object-type-code obj) :mop-object)))
+
 
 (defun clos-object-p (object) (eql (object-type-code object) :clos_object))
 

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -496,6 +496,7 @@
   (defparameter *basic-type-predicates*
     '((hash-table . hash-table-p) (package . packagep) (stream . streamp)
       (atom . atom) (structure . structure-p) (js-object . js-object-p)
+      (js-null . js-null-p) (js-undefined . js-undefined-p)
       ;; todo: subtypep - remove mop-object from tables
       (clos-object . mop-object-p) (mop-object . mop-object-p) (character . characterp)
       (symbol . symbolp)  (keyword . keywordp)

--- a/src/clos/std-object.lisp
+++ b/src/clos/std-object.lisp
@@ -22,6 +22,15 @@
 
 (/debug "loading std-object")
 
+;;; @vlad-km 20112022
+;;; clos override mode disable by default.
+;;; when you change this mode you know what you are doing
+(declaim (clos non-override))
+
+;;; manual op
+(defun clos-declaim-override (mode)
+  (setq *clos-override-mode*
+        (car (memq mode '(t nil)))))
 
 ;;; @vlad-km
 ;;; add hash/cn slots
@@ -431,17 +440,18 @@
 
 
 ;;; Ensure class
-;;; @vlad-km remove (setf...) form
+;;; @vlad-km 20112022 clos-override mode
 (defun ensure-class (name &rest all-keys)
   (if (!find-class name nil)
-      (error "Can't redefine the class named ~S." name)
-      (let* ((metaclass (get-keyword-from all-keys :metaclass *the-class-standard-class*))
-             (class (apply (if (eq metaclass *the-class-standard-class*)
-                               #'make-instance-standard-class
-                               #'make-instance)
-                           metaclass :name name all-keys)))
-        (setf-find-class name class)
-        class)))
+      (unless *clos-override-mode*
+        (error "Can't redefine the class named ~S." name)))
+  (let* ((metaclass (get-keyword-from all-keys :metaclass *the-class-standard-class*))
+         (class (apply (if (eq metaclass *the-class-standard-class*)
+                           #'make-instance-standard-class
+                           #'make-instance)
+                       metaclass :name name all-keys)))
+    (setf-find-class name class)
+    class))
 
 
 ;;; make-instance-standard-class creates and initializes an instance of

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1435,22 +1435,19 @@
 (define-raw-builtin oset (value object key &rest keys)
   (convert `(oset* (lisp-to-js ,value) ,object ,key ,@keys)))
 
-(define-builtin js-null-p (x)
+(define-builtin %js-null-p (x)
   (convert-to-bool `(=== ,x null)))
 
 (define-builtin objectp (x)
   (convert-to-bool `(=== (typeof ,x) "object")))
 
-;;; @vlad-km
-(define-builtin js-undefined-p (x)
+(define-builtin %js-undefined-p (x)
   (convert-to-bool `(== (typeof ,x) "undefined")))
 
-;;; return `null`
 (define-builtin %get-js-null% () ` (call-internal |makJSnull|))
-;;; return `undefined`
+
 (define-builtin %get-js-undef% () `(call-internal |makJSundef|))
-;;; return object with props `null/undef` and access methods
-(define-builtin %get-js-bvo% ()   `(call-internal |badJSvalues|))
+
 
 (define-builtin %%nlx-p (x)
   (convert-to-bool `(call-internal |isNLX| ,x)))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1365,7 +1365,7 @@
     (var (x ,vector))
     (var (i ,n))
     (if (or (< i 0) (>= i (get x "length")))
-        (throw "Out of range."))
+        (throw "set vector index out of range."))
     (return (= (property x i) ,value))))
 
 (define-builtin storage-vector-set! (vector n value)

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1343,13 +1343,6 @@
 (define-builtin resize-storage-vector (vector new-size)
   `(= (get ,vector "length") ,new-size))
 
-#+nil
-(define-builtin storage-vector-ref (vector n)
-  `(selfcall
-    (var (x (property ,vector ,n)))
-    (if (=== x undefined) (throw "Out of range."))
-    (return x)))
-;;; @vald-km 20112022
 ;;; if the object is a vector, if the vector index does not exceed its length,
 ;;; we return any value at this index, and do not puzzle over what out of range is.
 ;;; we deal with the content at the application level.

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1430,8 +1430,9 @@
 (define-builtin objectp (x)
   (convert-to-bool `(=== (typeof ,x) "object")))
 
+;;; @vlad-km
 (define-builtin js-undefined-p (x)
-  (convert-to-bool `(=== ,x undefined)))
+  (convert-to-bool `(== (typeof ,x) "undefined")))
 
 (define-builtin %%nlx-p (x)
   (convert-to-bool `(call-internal |isNLX| ,x)))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -151,7 +151,10 @@
     (constant
      (dolist (name (cdr decl))
        (let ((b (global-binding name 'variable 'variable)))
-         (push 'constant (binding-declarations b)))))))
+         (push 'constant (binding-declarations b)))))
+    (clos
+     (setq *clos-override-mode* (car (memq (cadr decl) '(override)))))
+    (otherwise nil)))
 
 #+jscl
 (fset 'proclaim #'!proclaim)

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1445,6 +1445,13 @@
 (define-builtin js-undefined-p (x)
   (convert-to-bool `(== (typeof ,x) "undefined")))
 
+;;; return `null`
+(define-builtin %get-js-null% () ` (call-internal |makJSnull|))
+;;; return `undefined`
+(define-builtin %get-js-undef% () `(call-internal |makJSundef|))
+;;; return object with props `null/undef` and access methods
+(define-builtin %get-js-bvo% ()   `(call-internal |badJSvalues|))
+
 (define-builtin %%nlx-p (x)
   (convert-to-bool `(call-internal |isNLX| ,x)))
 

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1343,10 +1343,21 @@
 (define-builtin resize-storage-vector (vector new-size)
   `(= (get ,vector "length") ,new-size))
 
+#+nil
 (define-builtin storage-vector-ref (vector n)
   `(selfcall
     (var (x (property ,vector ,n)))
     (if (=== x undefined) (throw "Out of range."))
+    (return x)))
+;;; @vald-km 20112022
+;;; if the object is a vector, if the vector index does not exceed its length,
+;;; we return any value at this index, and do not puzzle over what out of range is.
+;;; we deal with the content at the application level.
+(define-builtin storage-vector-ref (vector n)
+  `(selfcall
+    (if (>= ,n (get ,vector "length"))
+        (throw "ref vector index out of range."))
+    (var (x (property ,vector ,n)))
     (return x)))
 
 (define-builtin storage-vector-set (vector n value)

--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -73,4 +73,10 @@
 (defun js-null-p (obj) (js-null-p obj))
 (defun js-undefined-p (obj) (js-undefined-p obj))
 
+;;; @vlad-km 2011 2022
+(defun get-js-null () (%get-js-null%))
+(defun get-js-undefined () (%get-js-undef%))
+(defun get-js-bvo () (%get-js-bvo%))
+
+
 ;;; EOF

--- a/src/ffi.lisp
+++ b/src/ffi.lisp
@@ -70,13 +70,13 @@
       nil
       t))
 
-(defun js-null-p (obj) (js-null-p obj))
-(defun js-undefined-p (obj) (js-undefined-p obj))
+(defun js-null-p (obj) (%js-null-p obj))
 
-;;; @vlad-km 2011 2022
+(defun js-undefined-p (obj) (%js-undefined-p obj))
+
 (defun get-js-null () (%get-js-null%))
+
 (defun get-js-undefined () (%get-js-undef%))
-(defun get-js-bvo () (%get-js-bvo%))
 
 
 ;;; EOF

--- a/src/load.lisp
+++ b/src/load.lisp
@@ -216,7 +216,7 @@
                      (t t)) ))
          (error (msg)
            (format t "   Error: ")
-           (load_cond_err_handl_ msg)
+           (_load_cond_err_handl_ msg)
            ;; break read-eval loop
            ;; no bundle
            (setq fbundle nil)

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -42,17 +42,18 @@ else if (typeof window !== 'undefined')
 // object _jsBadValues
 // JS bad values such as `null` and `undefined` are now available
 // through this object in the lisp environment
-// o-JS-bv = oget #j:_jsBadValues
-// v-null = ((oget o-js-bv "gvN"))
+// bvo = (get-js-bvo)
+// v-null = (get-js-null)
+// u-null = (get-js-undefined)
 // (make-list 5 :initial-element  v-null)
 //
 // Important:
-//    (defvar *v-null* ((oget o-js-bv "gvN")))
+//    (defvar *v-null* (get-js-null)
 //                BUT!
-//    (defconstant +v-undef+ ((oget o-js-bv "gvN")))
+//    (defconstant +v-undef+ (get-js-undefined))
 // 
-//    (defconstant v-undef (#j:_jsBadValues:makUndef))
-//    (defconstant v-null (#j:_jsBadValues:makNull))
+//    (defconstant v-undef (get-js-undefined)
+//    (defconstant v-null (get-js-null))
 //
 // also you may use native array with null/undefined values
 // see test case for details
@@ -66,38 +67,11 @@ var _jsBadValues = {
  makUndef: function () { return this._wtf[1];}
 };
 
-if (typeof module !== 'undefined')
-  module.exports = _jsBadValues;
-else if (typeof window !== 'undefined')
-  window._jsBadValues = _jsBadValues;
-
-// @vlad-km
-// Next
-// in some cases, you may need to use direct access to these oddities.
-// the current implementation of ffi:get is not always predictable in the results.
-// it's an experiment.
-// for this, two functions have been implemented with access to an associative object
-// to obtain null and undef:
-//    (defvar *v-null* (#j:_makNull))
-//    (defconstant +v-undef+ (#j:_makUndef))
-var _wtf_ = {_n:null, _u:undefined};
-var _makNull = function() { return _wtf_['_n'];};
-var _makUndef = function () { return _wtf_['_u'];};
-
-if (typeof module !== 'undefined') {
-  module.exports = _wtf_;
-  module.exports = _makNull;
-  module.exports = _makUndef;
-    }
-else if (typeof window !== 'undefined') {
-  window._wtf = _wtf;
-  window._makNull = _makNull;
-  window._makUndef = _makUndef;
-    };
-
-
-
 var internals = jscl.internals = Object.create(null);
+
+internals.makJSnull = function () {return null;};
+internals.makJSundef = function () {return undefined;};
+internals.badJSvalues = function () {return _jsBadValues;};
 
 internals.globalEval = function(code){
   var geval = eval;             // Just an indirect eval

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -37,15 +37,12 @@ else if (typeof window !== 'undefined')
   window.jscl = jscl;
 
 
-// @vlad-km
-// EXPERIMENTAL features
-// object _jsBadValues
-// JS bad values such as `null` and `undefined` are now available
-// through this object in the lisp environment
-// bvo = (get-js-bvo)
-// v-null = (get-js-null)
-// u-null = (get-js-undefined)
-// (make-list 5 :initial-element  v-null)
+var internals = jscl.internals = Object.create(null);
+
+// NOTE: EXPERIMENTAL features
+//   v-null = (get-js-null)
+//   u-null = (get-js-undefined)
+//   (make-list 5 :initial-element  v-null)
 //
 // Important:
 //    (defvar *v-null* (get-js-null)
@@ -54,21 +51,6 @@ else if (typeof window !== 'undefined')
 // 
 //    (defconstant v-undef (get-js-undefined)
 //    (defconstant v-null (get-js-null))
-//
-// also you may use native array with null/undefined values
-// see test case for details
-var _jsBadValues = {
- _n: null,
- _u: undefined,
- gvN: function () {return this._n;},
- gvU: function () {return this._u;},
- _wtf:[null, undefined],
- makNull: function() { return this._wtf[0];},
- makUndef: function () { return this._wtf[1];}
-};
-
-var internals = jscl.internals = Object.create(null);
-
 internals.makJSnull = function () {return null;};
 internals.makJSundef = function () {return undefined;};
 internals.badJSvalues = function () {return _jsBadValues;};

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -56,7 +56,7 @@ else if (typeof window !== 'undefined')
 //
 // also you may use native array with null/undefined values
 // see test case for details
-window._jsBadValues = {
+var _jsBadValues = {
  _n: null,
  _u: undefined,
  gvN: function () {return this._n;},
@@ -65,6 +65,11 @@ window._jsBadValues = {
  makNull: function() { return this._wtf[0];},
  makUndef: function () { return this._wtf[1];}
 };
+
+if (typeof module !== 'undefined')
+  module.exports = _jsBadValues;
+else if (typeof window !== 'undefined')
+  window._jsBadValues = _jsBadValues;
 
 // @vlad-km
 // Next
@@ -76,8 +81,19 @@ window._jsBadValues = {
 //    (defvar *v-null* (#j:_makNull))
 //    (defconstant +v-undef+ (#j:_makUndef))
 var _wtf_ = {_n:null, _u:undefined};
-window._makNull = function() { return _wtf_['_n'];};
-window._makUndef = function () { return _wtf_['_u'];};
+var _makNull = function() { return _wtf_['_n'];};
+var _makUndef = function () { return _wtf_['_u'];};
+
+if (typeof module !== 'undefined') {
+  module.exports = _wtf;
+  module.exports = _makNull;
+  module.exports = _makUndef;
+    }
+else if (typeof window !== 'undefined') {
+  window._wtf = _wtf;
+  window._makNull = _makNull;
+  window._makUndef = _makUndef;
+    };
 
 
 

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -85,7 +85,7 @@ var _makNull = function() { return _wtf_['_n'];};
 var _makUndef = function () { return _wtf_['_u'];};
 
 if (typeof module !== 'undefined') {
-  module.exports = _wtf;
+  module.exports = _wtf_;
   module.exports = _makNull;
   module.exports = _makUndef;
     }

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -37,6 +37,50 @@ else if (typeof window !== 'undefined')
   window.jscl = jscl;
 
 
+// @vlad-km
+// EXPERIMENTAL features
+// object _jsBadValues
+// JS bad values such as `null` and `undefined` are now available
+// through this object in the lisp environment
+// o-JS-bv = oget #j:_jsBadValues
+// v-null = ((oget o-js-bv "gvN"))
+// (make-list 5 :initial-element  v-null)
+//
+// Important:
+//    (defvar *v-null* ((oget o-js-bv "gvN")))
+//                BUT!
+//    (defconstant +v-undef+ ((oget o-js-bv "gvN")))
+// 
+//    (defconstant v-undef (#j:_jsBadValues:makUndef))
+//    (defconstant v-null (#j:_jsBadValues:makNull))
+//
+// also you may use native array with null/undefined values
+// see test case for details
+window._jsBadValues = {
+ _n: null,
+ _u: undefined,
+ gvN: function () {return this._n;},
+ gvU: function () {return this._u;},
+ _wtf:[null, undefined],
+ makNull: function() { return this._wtf[0];},
+ makUndef: function () { return this._wtf[1];}
+};
+
+// @vlad-km
+// Next
+// in some cases, you may need to use direct access to these oddities.
+// the current implementation of ffi:get is not always predictable in the results.
+// it's an experiment.
+// for this, two functions have been implemented with access to an associative object
+// to obtain null and undef:
+//    (defvar *v-null* (#j:_makNull))
+//    (defconstant +v-undef+ (#j:_makUndef))
+var _wtf_ = {_n:null, _u:undefined};
+window._makNull = function() { return _wtf_['_n'];};
+window._makUndef = function () { return _wtf_['_u'];};
+
+
+
 var internals = jscl.internals = Object.create(null);
 
 internals.globalEval = function(code){

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -53,7 +53,6 @@ var internals = jscl.internals = Object.create(null);
 //    (defconstant v-null (get-js-null))
 internals.makJSnull = function () {return null;};
 internals.makJSundef = function () {return undefined;};
-internals.badJSvalues = function () {return _jsBadValues;};
 
 internals.globalEval = function(code){
   var geval = eval;             // Just an indirect eval

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -110,12 +110,6 @@ internals.newInstance = function(values, ct){
   return new newCt();
 };
 
-// Workaround the problem with send NULL for async XHR
-// BUG: future todo
-//var reqXHRsendNull = function(req){
-//  req.send(null);
-//};
-
 // Workaround the problem with operator precedence
 // ash
 internals.Bitwise_ash_R = function (x, y) { return x >> y;};

--- a/src/print.lisp
+++ b/src/print.lisp
@@ -279,10 +279,10 @@
 
 (defun write-aux (form stream known-objects object-ids)
   (when (js-null-p form)
-    (write "<JS-NULL>" :stream stream)
+    (write-string "<JS-NULL>" stream)
     (return-from write-aux))
   (when (js-undefined-p form)
-    (write "<JS-UNDEFINED>" :stream stream)
+    (write-string "<JS-UNDEFINED>" stream)
     (return-from write-aux))
   (when *print-circle*
     (let* ((ix (or (position form known-objects) 0))

--- a/src/print.lisp
+++ b/src/print.lisp
@@ -278,6 +278,12 @@
       (write-string (string-capitalize (char-name char)) stream)))
 
 (defun write-aux (form stream known-objects object-ids)
+  (when (js-null-p form)
+    (write "<JS-NULL>" :stream stream)
+    (return-from write-aux))
+  (when (js-undefined-p form)
+    (write "<JS-UNDEFINED>" :stream stream)
+    (return-from write-aux))
   (when *print-circle*
     (let* ((ix (or (position form known-objects) 0))
            (id (aref object-ids ix)))

--- a/src/toplevel.lisp
+++ b/src/toplevel.lisp
@@ -319,6 +319,9 @@
   (t
    (setq *root* (%js-vref "self"))))
 
+;;; mark *features* for this version
+(push :js-null-types *features*)
+
 (defun require (name)
   (if (find :node *features*)
       (funcall (%js-vref "require") name)))

--- a/src/toplevel.lisp
+++ b/src/toplevel.lisp
@@ -250,7 +250,7 @@
    with-output-to-string with-package-iterator with-simple-restart
    with-slots with-standard-io-syntax write write-byte write-char
    write-line write-sequence write-string write-to-string y-or-n-p
-   yes-or-no-p zerop))
+   yes-or-no-p zerop override non-override clos))
 
 (setq *package* *user-package*)
 

--- a/tests/clos.lisp
+++ b/tests/clos.lisp
@@ -328,6 +328,28 @@
              (mapcar (lambda (x) (class-name x)) (class-precedence-list (find-class 'q-clos)))))
 
 
+;;; test case (declaim (clos override))
+(defclass override-class nil (a))
+(test
+ (equal :good
+        (progn
+          (handler-case
+              (progn
+                (defclass override-class nil (e b d))
+                :bad)  
+            (error (m)  
+              (declaim (clos override))  
+              (handler-case  
+                  (progn
+                    (defclass override-class nil (e b d))
+                    (declaim (clos non-override))
+                    :good)  
+                (error (m)
+                  (declaim (clos non-override))
+                  :bad)))))))
+
+(test (null *clos-override-mode*))
+;;; end test case (declaim (clos override))
 
 
 

--- a/tests/ffi.lisp
+++ b/tests/ffi.lisp
@@ -68,11 +68,12 @@
 
 ;;; EXPERIMENTAL FFI
 ;;; _jsBadValues - new features
-(defconstant v-undef (#j:_jsBadValues:makUndef))
-(defconstant v-null (#j:_jsBadValues:makNull))
-(let* ((fob #j:_jsBadValues)
+(defconstant v-undef (jscl::get-js-undefined))
+(defconstant v-null (jscl::get-js-null))
+(let* ((fob (jscl::get-js-bvo))
        (js-null ((oget fob "gvN")))
        (js-undef ((oget fob "gvU")))
+       ((abv (jscl::oget fob "_wtf")))
        (js-ara (make-new #j:Array 1000))
        (nc)
        (nc2))
@@ -82,10 +83,10 @@
   (test (js-undefined-p js-undef))
   (test (js-null-p js-null))
 ;;; test native array with null/undefined values
-  (test (eq (aref #j:_jsBadValues:_wtf 0) js-null))
-  (test (eq (aref #j:_jsBadValues:_wtf 1) js-undef))
-  (test (eq (aref #j:_jsBadValues:_wtf 0) v-null))
-  (test (eq (aref #j:_jsBadValues:_wtf 1) v-undef))
+  ;;(test (eq (aref abv 0) js-null))
+  ;;(test (eq (aref abv 1) js-undef))
+  ;;(test (eq (aref abv 0) v-null))
+  ;;(test (eq (aref abv 1) v-undef))
 ;;; array test with values `undefined` and/or `null`
   (test (eq (aref js-ara 0) v-undef))
   (test (eq (aref js-ara 100) js-undef))

--- a/tests/ffi.lisp
+++ b/tests/ffi.lisp
@@ -65,4 +65,44 @@
   (test (oset 456 obj 123))
   (test (equal 456 (oget obj 123))))
 
+
+;;; EXPEDRIMENTAL FFI
+;;; _jsBadValues - new features
+(defconstant v-undef (#j:_jsBadValues:makUndef))
+(defconstant v-null (#j:_jsBadValues:makNull))
+(let* ((fob #j:_jsBadValues)
+       (js-null ((oget fob "gvN")))
+       (js-undef ((oget fob "gvU")))
+       (js-ara (make-new #j:Array 1000))
+       (nc)
+       (nc2))
+;;; test what v-undef & js-undef eq js: undefined
+  (test (js-undefined-p v-undef))
+  (test (js-null-p v-null))
+  (test (js-undefined-p js-undef))
+  (test (js-null-p js-null))
+;;; test native array with null/undefined values
+  (test (eq (aref #j:_jsBadValues:_wtf 0) js-null))
+  (test (eq (aref #j:_jsBadValues:_wtf 1) js-undef))
+  (test (eq (aref #j:_jsBadValues:_wtf 0) v-null))
+  (test (eq (aref #j:_jsBadValues:_wtf 1) v-undef))
+;;; array test with values `undefined` and/or `null`
+  (test (eq (aref js-ara 0) v-undef))
+  (test (eq (aref js-ara 100) js-undef))
+  (test (eq 1000 (count js-undef js-ara)))
+  (test (eq 1000 (count-if (lambda (x) (js-undefined-p x)) js-ara)))
+  (test (eq 1000 (count v-undef js-ara)))
+  (test (eq 1000 (count-if (lambda (x) (and (js-undefined-p x) (eq x v-undef))) js-ara)))
+  (test (progn
+          (handler-case
+              (progn
+                (loop for i from 1 below 99 do (setf (aref js-ara i) js-null))
+                t)
+            (error (m) nil))))
+  (test (eq (count js-null js-ara)
+            (count-if 
+                (lambda (x) (and (js-null-p x) (eq x v-null)))
+                js-ara))))
+
+
 ;;; EOF

--- a/tests/ffi.lisp
+++ b/tests/ffi.lisp
@@ -67,40 +67,26 @@
 
 
 ;;; EXPERIMENTAL FFI
-;;; _jsBadValues - new features
 (defconstant v-undef (jscl::get-js-undefined))
 (defconstant v-null (jscl::get-js-null))
-(let* ((fob (jscl::get-js-bvo))
-       (js-null ((oget fob "gvN")))
-       (js-undef ((oget fob "gvU")))
-       ((abv (jscl::oget fob "_wtf")))
-       (js-ara (make-new #j:Array 1000))
+(let* ((js-ara (make-new #j:Array 1000))
        (nc)
        (nc2))
 ;;; test what v-undef & js-undef eq js: undefined
   (test (js-undefined-p v-undef))
   (test (js-null-p v-null))
-  (test (js-undefined-p js-undef))
-  (test (js-null-p js-null))
-;;; test native array with null/undefined values
-  ;;(test (eq (aref abv 0) js-null))
-  ;;(test (eq (aref abv 1) js-undef))
-  ;;(test (eq (aref abv 0) v-null))
-  ;;(test (eq (aref abv 1) v-undef))
-;;; array test with values `undefined` and/or `null`
   (test (eq (aref js-ara 0) v-undef))
-  (test (eq (aref js-ara 100) js-undef))
-  (test (eq 1000 (count js-undef js-ara)))
+  (test (eq 1000 (count v-undef js-ara)))
   (test (eq 1000 (count-if (lambda (x) (js-undefined-p x)) js-ara)))
   (test (eq 1000 (count v-undef js-ara)))
   (test (eq 1000 (count-if (lambda (x) (and (js-undefined-p x) (eq x v-undef))) js-ara)))
   (test (progn
           (handler-case
               (progn
-                (loop for i from 1 below 99 do (setf (aref js-ara i) js-null))
+                (loop for i from 1 below 99 do (setf (aref js-ara i) v-null))
                 t)
             (error (m) nil))))
-  (test (eq (count js-null js-ara)
+  (test (eq (count v-null js-ara)
             (count-if 
                 (lambda (x) (and (js-null-p x) (eq x v-null)))
                 js-ara))))


### PR DESCRIPTION
**Closed issue #392**

Added global declaration _**(declaim (clos override))**_, after declaring which, you can override existing classes. 
_**Unsafe mode.**_
While the integrity of already existing classes is not reviewed.
The mode is canceled by declaration _**(declaim (clos non-override))**_

Details see at `tests\clos.lisp`
_**If you use this mode, you know what you are doing.**_

Closes #392 
Closes #458 
Closes #459 

**Experimental FFI feature**

Added  fi functions: 
`(jscl::get-js-null)` => js:null
`(jscl::get-js-undefined)` => js:undefined

```lisp
JSCL version 0.8.2 built on 30 November 2022

CL-USER> 
CL-USER> 
CL-USER> (jscl::get-js-null)
<js-null>
CL-USER> (jscl::get-js-undefined)
<JS-UNDEFINED>
CL-USER> (jscl::js-null-p (jscl::get-js-null))
T
CL-USER> (jscl::js-undefined-p (jscl::get-js-undefined))
T
CL-USER> 
```


Now JS values, such as *`null`* and *`undefined`*, are available in the Lisp environment.

```lisp
;;; Important:
    (defconstant +v-null+  (jscl::get-js-null))   OR
    (defvar *v-null* (jscl::get-js-null))
;;;                BUT!
    (defconstant +v-undef+ (jscl::get-js-undefined)) 
;;; other details see at  tests\ffi.lisp
    (setq alu (make-list 5 ::initial-element  +v-null+))
    (setq ara (make-new #j:Array 1000))
    (setf (aref ara 2) 123)
    (setf (oget ara "issue") 392)
    (aref ara 2) 
    (typecase (aref ara 900) (jscl::js-null :null) (jscl::js-undefined :undef) (t :damn))
;;;    ... etc 
```

Have fun,
@vlad-km
