### PR TITLE
Fix backquote on dotted pairs

### DIFF
--- a/src/backquote.lisp
+++ b/src/backquote.lisp
@@ -223,7 +223,11 @@
 ;;;  (op item 'nil) => (op item), if item is a splicable frob
 ;;;  (op item (op a b c)) => (op item a b c)
 (defun bq-attach-append (op item result)
-  (cond ((and (null-or-quoted item) (null-or-quoted result))
+  (cond ((and (atom item) (null result))
+         (list *bq-quote* item))
+        ((and (atom (cadr item)) (null result))
+         (list *bq-quote* (cadr item)))
+        ((and (null-or-quoted item) (null-or-quoted result))
          (list *bq-quote* (append (cadr item) (cadr result))))
         ((or (null result) (equal result *bq-quote-nil*))
          (if (bq-splicing-frob item) (list op item) item))


### PR DESCRIPTION
This commit adds a couple extra cases to backquote's simplification step, which accounts for if the expression is an improper list or dotted pair.

I'm not super happy with this implementation, since I'm not 100% sure these cases account for everything, but it seems to work correctly.