### PR TITLE
Update prelude.js to eval scripts correctly

### DIFF
--- a/src/prelude.js
+++ b/src/prelude.js
@@ -464,7 +464,7 @@ function runCommonLispScripts() {
             continue;
         }
 
-        if("src" in documentScripts[i]) {
+        if("src" in documentScripts[i] && documentScripts[i].src.length != 0) {
             script = {
                 executed: false,
                 error: false,


### PR DESCRIPTION
At least in Firefox the documentScripts[i].src is read as "" when there's no src attribute, this leads to attempt to evaluate the whole document HTML.

Without this I get error
```
Unexpected EOF [jscl.js:47215:108](http://172.18.0.2:8080/jscl.js)
Uncaught Error: Variable <!DOCTYPE is unbound.
```
when the `prelude.js` attempt to evaluate the whole document instead of script.