### PR TITLE
Fix backquote on dotted pairs, close #492

### DIFF
--- a/src/backquote.lisp
+++ b/src/backquote.lisp
@@ -223,10 +223,11 @@
 ;;;  (op item 'nil) => (op item), if item is a splicable frob
 ;;;  (op item (op a b c)) => (op item a b c)
 (defun bq-attach-append (op item result)
-  (cond ((and (null-or-quoted item) (null-or-quoted result))
-         (list *bq-quote* (append (cadr item) (cadr result))))
-        ((or (null result) (equal result *bq-quote-nil*))
+  ;; switch order of first two branches due to issue #492
+  (cond ((or (null result) (equal result *bq-quote-nil*))
          (if (bq-splicing-frob item) (list op item) item))
+        ((and (null-or-quoted item) (null-or-quoted result))
+         (list *bq-quote* (append (cadr item) (cadr result))))
         ((and (consp result) (eq (car result) op))
          (list* (car result) item (cdr result)))
         (t (list op item result))))

--- a/tests/read.lisp
+++ b/tests/read.lisp
@@ -118,6 +118,18 @@
       (jscl::vector-to-list s1)
       '(1 2 3 4 5 6 7 8 9 10))))))
 
+;;; backquote
+
+(test (equal '(x (a b c) a b c foo b bar (b c) baz b c)
+             (let ((x (list 'a 'b 'c)))
+               `(x ,x ,@x foo ,(cadr x) bar ,(cdr x) baz ,@(cdr x)))))
+
+(test (equal '(a . b) `(a . b)))
+
+(test (equal '(a b . 1)
+             (let ((x 1))
+               `(a b . ,x))))
+
 ;;;
 ;;; parse-integer
 ;;;


### PR DESCRIPTION
After my own investigation of #492 and #494, this is the solution I come up. It just adds one null case and seems to work.

@SuperDisk @hemml do you think my solution cover all cases?