### PR TITLE
Implement and use part of ANSI condition hierarchy

### DIFF
--- a/web/repl.lisp
+++ b/web/repl.lisp
@@ -84,8 +84,9 @@
 (defparameter +err-css+ "jqconsole-error")
 
 (defun display-condition (c &optional (style +err-css+) (newline t))
-  (errmsg-prefix)
-  (#j:jqconsole:Write (princ-to-string c) style)
+  (#j:jqconsole:Write (format nil "~A: ~A"
+                              (class-name (class-of c)) c)
+                      style)
   (when newline (%console-terpri)))
 
 


### PR DESCRIPTION
- Defines all of ANSI CL's condition hierarchy except `method-combination-error`.
- Try to use typed conditions as specified in the standard after `conditions.lisp` is loaded.
  - I haven't really touched `error`s before `conditions.lisp` is loaded and in the JS internals, mostly because I'm worried about bootstrapping quirks. The bootstrap definition of `error` seems to assume a particular usage pattern (string followed by a simple S-expr) and using typed condition would likely break it.
- UI change: display error types.

For example, now we have
```
CL-USER> (setf (documentation 'defun 'function) 1)
SIMPLE-TYPE-ERROR: Check type error.
The value of JSCL::NEW-VAL is 1, is not a STRING.
```
I think displaying condition type is more informative than hard coded "ERROR: " prefix. However sometimes the package prefix become a bit unweildy:
```
CL-USER> (read-from-string "(")
JSCL::READER-EOF-ERROR: End of file on #<structure stream>.
```
Despite not the most visually appealing, I still think it's best to include package prefixes to avoid information loss.

I'm happy to hear comments and suggestions about the UI!