### PR TITLE
bind *package* in with-compilation-environment, close #258

### DIFF
--- a/src/load.lisp
+++ b/src/load.lisp
@@ -61,7 +61,8 @@
 (defun _load_form_eval_ (input verbose)
   (let ((stream)
         (expr)
-        (eof (gensym "LOADER" )))
+        (eof (gensym "LOADER" ))
+        (*package* *package*))
     (setq stream (make-string-input-stream input))
     (terpri)
     (tagbody
@@ -188,7 +189,8 @@
    hook))
 
 (defun _load_eval_bundle_ (input verbose bundle-name place hook)
-  (let (stream eof code expr rc code-stor fbundle)
+  (let ((*package* *package*)
+        stream eof code expr rc code-stor fbundle)
     (setq eof (gensym "LOADER"))
     (if hook (setq code-stor hook))
     (when bundle-name


### PR DESCRIPTION
This is a simple patch which seem to fix #258 and does not break any test.

I'm not familiar enough to be sure it's correct, can someone take a look?