### PR TITLE
Implements prog*.

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -286,6 +286,13 @@
          ,@decls
          (tagbody ,@forms)))))
 
+(defmacro prog* (inits &rest body)
+  (multiple-value-bind (forms decls) (parse-body body :declarations t)
+    `(block nil
+       (let* ,inits
+         ,@decls
+         (tagbody ,@forms)))))
+
 (defmacro psetq (&rest pairs)
   (let (;; For each pair, we store here a list of the form
         ;; (VARIABLE GENSYM VALUE).


### PR DESCRIPTION
Also add tests for `prog` and `prog*`. These tests are shamelessly copied and adopted from https://github.com/cxxxr/valtan/blob/master/tests/sacla-tests/must-data-and-control.lisp

Note that tests use `(declare (special ...))` were commented out since JSCL doesn't support `declare` now.