### PR TITLE
implement full minimal semantics of CONSTANTP

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -446,19 +446,6 @@
                           (nth ,n values))
      ,form))
 
-(defun constantp (x)
-  ;; TODO: Consider quoted forms, &environment and many other
-  ;; semantics of this function.
-  (cond
-    ((symbolp x)
-     (cond
-       ((eq x t) t)
-       ((eq x nil) t)))
-    ((atom x)
-     t)
-    (t
-     nil)))
-
 (defparameter *features* '(:jscl :common-lisp))
 
 ;;; symbol-function from compiler macro

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -166,6 +166,18 @@
 (defmacro define-symbol-macro (name expansion)
   `(%define-symbol-macro ',name ',expansion))
 
+(defun !constantp (x &optional environment)
+  (let ((env (or environment *global-environment*)))
+    (cond
+      ((symbolp x)
+       (awhen (lookup-in-lexenv x env 'variable)
+         (member 'constant (binding-declarations it))))
+      ((consp x)
+       (eq (car x) 'quote))
+      (t t))))
+
+#+jscl
+(fset 'constantp #'!constantp)
 
 
 ;;; Report functions which are called but not defined


### PR DESCRIPTION
This implements the minimal requirement to be compliant with https://www.lispworks.com/documentation/HyperSpec/Body/f_consta.htm

My only question is this move `constantp` from `boot.lisp` to `compiler/compiler.lisp`. `constantp` is used before in `ansi-loop/ansi-loop.lisp`, but this does not break bootstrap because it only use it at macroexpansion time (in which case it can use host's `constantp`). Are we ok with this?

I think this is fine because `loop` is intended to use `constantp` in macroexpansion time anyway and it's unlikely someone make some change and suddenly break bootstrap because of this. But if that does happen, it would be very confusing! 