### PR TITLE
Use constant vector to pass literal objects in EVAL, close #527

### DIFF
--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -589,9 +589,9 @@
   (let ((head (butlast cons))
         (tail (last cons)))
     `(call-internal |QIList|
-                    ,@(mapcar (lambda (x) (literal x t)) head)
-                    ,(literal (car tail) t)
-                    ,(literal (cdr tail) t))))
+                    ,@(mapcar (lambda (x) (literal x)) head)
+                    ,(literal (car tail))
+                    ,(literal (cdr tail)))))
 
 (defun dump-array (array)
   (let ((elements (vector-to-list array))
@@ -608,33 +608,41 @@
 (defun dump-string (string)
   `(call-internal |make_lisp_string| ,string))
 
-(defun literal (sexp &optional recursive)
+;;; Was the compiler invoked by EVAL for in-process evaluation?
+(defvar *compiling-in-process* nil)
+
+(defun literal (sexp)
   (cond
     ((integerp sexp) sexp)
     ((floatp sexp) sexp)
     ((characterp sexp) (string sexp))
     (t
      (or (cdr (assoc sexp *literal-table* :test #'eql))
-         (let ((dumped (typecase sexp
-                         (symbol (dump-symbol sexp))
-                         (string (dump-string sexp))
-                         (cons
-                          ;; BOOTSTRAP MAGIC: See the root file
-                          ;; jscl.lisp and the function
-                          ;; `dump-global-environment' for further
-                          ;; information.
-                          (if (eq (car sexp) *magic-unquote-marker*)
-                              (convert (second sexp))
-                              (dump-cons sexp)))
-                         (array (dump-array sexp)))))
-           (if (and recursive (not (symbolp sexp)))
-               dumped
-               (let ((jsvar (genlit)))
-                 (push (cons sexp jsvar) *literal-table*)
+         (let ((index *literal-counter*)
+               (jsvar (genlit)))
+           (push (cons sexp jsvar) *literal-table*)
+           (if *compiling-in-process*
+               ;; If compiling for in-process evaluation, arrange to pass
+               ;; literals directly via data vector, instead of dumping
+               ;; them to reconstruction code
+               (toplevel-compilation
+                `(var (,jsvar (property |data| ,index))))
+               (let ((dumped (typecase sexp
+                               (symbol (dump-symbol sexp))
+                               (string (dump-string sexp))
+                               (cons
+                                ;; BOOTSTRAP MAGIC: See the root file
+                                ;; jscl.lisp and the function
+                                ;; `dump-global-environment' for further
+                                ;; information.
+                                (if (eq (car sexp) *magic-unquote-marker*)
+                                    (convert (second sexp))
+                                    (dump-cons sexp)))
+                               (array (dump-array sexp)))))
                  (toplevel-compilation `(var (,jsvar ,dumped)))
                  (when (keywordp sexp)
-                   (toplevel-compilation `(= (get ,jsvar "value") ,jsvar)))
-                 jsvar)))))))
+                   (toplevel-compilation `(= (get ,jsvar "value") ,jsvar)))))
+           jsvar)))))
 
 
 (define-compilation quote (sexp)
@@ -1325,12 +1333,12 @@
 			       this
 			       args))))))
 
-(define-builtin js-eval (string)
+(define-builtin js-eval (string data)
   (if *multiple-value-p*
       `(selfcall
-        (var (v (call-internal |globalEval| (call-internal |xstring| ,string))))
+        (var (v (call-internal |globalEval| (call-internal |xstring| ,string) ,data)))
         (return (method-call |values| "apply" this (call-internal |forcemv| v))))
-      `(call-internal |globalEval| (call-internal |xstring| ,string))))
+      `(call-internal |globalEval| (call-internal |xstring| ,string) ,data)))
 
 (define-builtin %throw (string)
   `(selfcall (throw ,string)))

--- a/src/load.lisp
+++ b/src/load.lisp
@@ -209,7 +209,7 @@
              (when verbose (format t "~a ~a~%" (car expr) (cadr expr)))
              (with-compilation-environment
                (setq code (compile-toplevel expr t t))
-               (setq rc (js-eval code))
+               (setq rc (js-eval code nil))
                (when verbose (format t "  ~a~%" rc))
                ;; so, expr already verifyed
                ;; store expression after compilation/evaluated

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -39,10 +39,10 @@ else if (typeof self !== 'undefined')
 
 var internals = jscl.internals = Object.create(null);
 
-internals.globalEval = function(code){
+internals.globalEval = function(code, data){
   var geval = eval;             // Just an indirect eval
-  var fn = geval('(function(values, internals){ "use strict"; ' + code + '; })');
-  return fn(internals.mv, internals);
+  var fn = geval('(function(values, internals, data){ "use strict"; ' + code + '; })');
+  return fn(internals.mv, internals, data);
 };
 
 internals.pv = function(x) {

--- a/src/toplevel.lisp
+++ b/src/toplevel.lisp
@@ -19,10 +19,12 @@
 (/debug "loading toplevel.lisp!")
 
 (defun eval (x)
-  (let ((jscode
-         (with-compilation-environment
-             (compile-toplevel x t t))))
-    (js-eval jscode)))
+  (multiple-value-bind (jscode literal-table)
+      (let ((*compiling-file* nil)
+            (*compiling-in-process* t))
+        (with-compilation-environment
+          (values (compile-toplevel x t t) *literal-table*)))
+    (js-eval jscode (list-to-vector (nreverse (mapcar #'car literal-table))))))
 
 (defvar * nil)
 (defvar ** nil)

--- a/tests/eval.lisp
+++ b/tests/eval.lisp
@@ -8,4 +8,19 @@
               (eval '(defun test-fun (x y)
                       (+ x y)))
               (eval '(test-fun 40 2)))))
+
+
+;;; CLHS 3.2.4.4
+(test (let ((name (gensym)))
+        (eq name (eval `',name))))
+
+(test (let* ((name (gensym))
+             (list (eval `'(,name ,name))))
+        (eq (car list) (cadr list))))
+
+(test (equal "FOO"
+             (let ((name (gensym)))
+               (eval `(defvar ,name "FOO"))
+               (symbol-value name))))
+
 ;;; EOF


### PR DESCRIPTION
This touches some fairly low level stuff so I'd like to get a review :)

There's also one more thing I'd like to do (but haven't yet). We really shouldn't need a separate flag `*compiling-for-eval*` from `*compile-file*`, if not for the `output` argument in `load`... So during `load`, we have to *not* use `:compile-toplevel` semantics for `eval-when`, but *do* use file dumping logic for literal objects because we might want `load` to generate an output file.

I don't think `load` is ever intended to be used for generating output file. 
> load sequentially executes each form it encounters in the file named by filespec. If the file is a source file and the implementation chooses to perform implicit compilation, load must recognize top level forms as described in Section 3.2.3.1 (Processing of Top Level Forms) and arrange for each top level form to be executed before beginning implicit compilation of the next. (Note, however, that processing of eval-when forms by load is controlled by the :execute situation.)

We should use `compile-file` to generate output file. We currently have `!compile-file`, but likely only suited for the host. If desired I can take a shot at implementing it in target. Then we can remove `output` argument from `load`, and unify `*compiling-for-eval*` with `*compiling-file*`. What do you think?

Although I am aware the right approach to `compile-file` would probably require a significant chunk of file I/O dictionary (which in turn require a more complete stream subsystem). If this turns out to be too large a project, we can either merge this in its current state or just postpone it. It's not mission critical -- it just cause some `alexandria` tests to fail.