### PR TITLE
Remove `define-transformation` and implment `backquote` as macro.

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -48,6 +48,9 @@
     
     (%compile-defmacro 'defmacro defmacro-macroexpander)))
 
+(defmacro backquote (form)
+  (bq-completely-process form))
+
 (defmacro declaim (&rest decls)
   `(eval-when (:compile-toplevel :execute)
      ,@(mapcar (lambda (decl) `(!proclaim ',decl)) decls)))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -727,10 +727,6 @@
     (t
      (convert nil))))
 
-(defmacro define-transformation (name args form)
-  `(define-compilation ,name ,args
-     (convert ,form)))
-
 (define-compilation progn (&rest body)
   `(progn
      ,@(append (mapcar #'convert (butlast body))
@@ -1056,11 +1052,6 @@
 
 (define-compilation the (value-type form)
   (convert form *multiple-value-p*))
-
-
-(define-transformation backquote (form)
-  (bq-completely-process form))
-
 
 ;;; Primitives
 


### PR DESCRIPTION
See
https://github.com/jscl-project/jscl/discussions/520#discussioncomment-15213129 for the rationale.