### PR TITLE
more and better sequence functions

### DIFF
--- a/src/array.lisp
+++ b/src/array.lisp
@@ -151,23 +151,24 @@ in which case ARRAY might be partially filled from CONTENTS."
       (length (oget array "dimensions"))))
 
 (defun array-row-major-index (array &rest subscripts)
-  (if (vectorp array)
-      (car subscripts)
-      (let ((result 0)
-            (subs subscripts)
-            (dimensions (oget array "dimensions")))
-        (while dimensions
-          (unless subs
-            (error "Too few subscripts ~a for ~a" subscripts array))
-          (let ((subscript (pop subs))
-                (dimension (pop dimensions)))
-            (unless (<= 0 subscript (1- dimension))
-              (error "Subscript ~d out of range for dimension ~d"
-                     subscript dimension))
-            (setq result (+ subscript (* result dimension)))))
-        (when subs
-          (error "Too many subscripts ~a for ~a" subscripts array))
-        result)))
+  (cond ((vectorp array) (car subscripts))
+        ((arrayp array)
+         (let ((result 0)
+               (subs subscripts)
+               (dimensions (oget array "dimensions")))
+           (while dimensions
+             (unless subs
+               (error "Too few subscripts ~a for ~a" subscripts array))
+             (let ((subscript (pop subs))
+                   (dimension (pop dimensions)))
+               (unless (<= 0 subscript (1- dimension))
+                 (error "Subscript ~d out of range for dimension ~d"
+                        subscript dimension))
+               (setq result (+ subscript (* result dimension)))))
+           (when subs
+             (error "Too many subscripts ~a for ~a" subscripts array))
+           result))
+        (t (error 'type-error :datum array :expected-type 'array))))
 
 (defun array-total-size (array)
   (unless (arrayp array)

--- a/tests/seq.lisp
+++ b/tests/seq.lisp
@@ -405,5 +405,9 @@
              (let ((vec (vector 0 0 0)))
                (setf (elt vec 0) 42)
                vec)))
+(test (equal '(42 0 0)
+             (let ((list (list 0 0 0)))
+               (setf (elt list 0) 42)
+               list)))
 
 ;;; EOF


### PR DESCRIPTION
- Efficient START/END options for all
- FROM-END for many
- Complete implementation of `some`,`every`,`notany`,`notevery` (previously `some` doesn't support more sequeunces)
- COUNT option for `remove-*`. It also now uses a smarter algorithm which I'm quite proud of ;)
- (SETF SUBSEQ)
- SUBSTITUE, SUBSTITUTE-IF, SUBSTITUTE-IF-NOT, with START, END, COUNT options

Many shared logic went into the `do-sequence` macro. ~~I also used local `frob`/`def` macro in some places.~~ I also defined a `define-seq-variants` macro. I think this is the only manageable strategy towards implement full sequence dictionary, but feel free to voice other opinion. This is the reason I want a review!