### PR TITLE
move compiler before CLOS in the boot process

### DIFF
--- a/jscl.lisp
+++ b/jscl.lisp
@@ -78,6 +78,16 @@
     ("hash-table"    :target)
     ("types-prelude" :both)
     ("types"         :target)
+    ("ansiloop"
+     ("ansi-loop"    :both))
+    ("stream"        :target)
+    ("print"         :target)
+    ("misc"          :target)
+    ("read"          :both)
+    ("backquote"     :both)
+    ("compiler"
+     ("codegen"      :both)
+     ("compiler"     :both))
     ("clos"
      ("kludges"       :target)
      ("std-object"    :target)
@@ -88,17 +98,7 @@
      ("macros"        :target)
      ("methods"       :target))
     ("conditions"    :target)
-    ("ansiloop"
-     ("ansi-loop"    :both))
     ("structures"    :both)
-    ("stream"        :target)
-    ("print"         :target)
-    ("misc"          :target)
-    ("read"          :both)
-    ("backquote"     :both)
-    ("compiler"
-     ("codegen"      :both)
-     ("compiler"     :both))
     ("format"        :both)
     ("documentation" :target)
     ("worker"        :target)

--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -561,18 +561,20 @@
 
 ;;; Early error definition.
 (defun %coerce-panic-arg (arg)
-  (cond ((symbolp arg) (concat "symbol: " (symbol-name arg)))
-        ((consp arg ) (concat "cons: " (car arg)))
-        ((numberp arg) (concat "number:" arg))
-        (t " @ ")))
+  (if (fboundp 'prin1-to-string)
+      (concat (prin1-to-string arg) " ")
+      (cond ((symbolp arg) (concat "symbol: " (symbol-name arg) " "))
+            ((consp arg) (concat "cons: " (car arg)  " "))
+            ((numberp arg) (concat "number:" arg  " "))
+            (t "@ "))))
 
 ;;; N.B. The following definition is functional after `string.lisp' is
 ;;; loaded, and superseded after `conditions.lisp' is loaded.
 (defun error (fmt &rest args)
-  (%throw (lisp-to-js (concat "BOOT PANIC! "
-                              (string fmt)
-                              " "
-                              (%coerce-panic-arg (car args))))))
+  (%throw (lisp-to-js (apply #'concat "BOOT PANIC! "
+                             (string fmt)
+                             " "
+                             (mapcar #'%coerce-panic-arg args)))))
 
 ;;; print-unreadable-object
 (defmacro !print-unreadable-object ((object stream &key type identity) &body body)

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -109,10 +109,24 @@
           :reader cell-error-name)))
 (%define-condition undefined-function (cell-error) ())
 (%define-condition unbound-variable (cell-error) ())
+
+;;; Conditions used in previous bootstrap process
 (%define-condition package-error (error) ()
    ((package :initform nil
              :initarg :package
              :reader package-error-package)))
+(%define-condition stream-error (error)
+   ((stream :initform nil
+            :initarg :stream
+            :reader stream-error-stream)))
+(%define-condition end-of-file (stream-error) ()
+   (:report (lambda (condition stream)
+              (format stream "End of file on ~S." (stream-error-stream condition)))))
+(%define-condition reader-error (parse-error stream-error) ())
+(%define-condition simple-reader-error (simple-condition reader-error) ())
+(%define-condition simple-reader-package-error (simple-reader-error package-error) ())
+(%define-condition reader-eof-error (reader-error end-of-file) ())
+(%define-condition simple-parse-error (simple-condition parse-error) ())
 
 (defun %%make-condition (type &rest slot-initializations)
     (apply #'make-instance type slot-initializations))

--- a/src/read.lisp
+++ b/src/read.lisp
@@ -645,14 +645,6 @@
 #+jscl
 (fset 'read-from-string #'ls-read-from-string)
 
-#+jscl
-(define-condition reader-error (parse-error stream-error) ())
-
-(define-condition simple-reader-error (simple-condition reader-error) ())
-(define-condition simple-reader-package-error (simple-reader-error package-error) ())
-(define-condition reader-eof-error (reader-error end-of-file) ())
-(define-condition simple-parse-error (simple-condition parse-error) ())
-
 (defun simple-reader-error (stream format-control &rest format-arguments)
   (error 'simple-reader-error
          :stream stream

--- a/src/stream.lisp
+++ b/src/stream.lisp
@@ -171,15 +171,4 @@
             (values nil t))
         (values string eof))))
 
-;;; Conditions
-
-(define-condition stream-error (error)
-  ((stream :initform nil
-           :initarg :stream
-           :reader stream-error-stream)))
-
-(define-condition end-of-file (stream-error) ()
-  (:report (lambda (condition stream)
-             (format stream "End of file on ~S." (stream-error-stream condition)))))
-
 ;;; EOF


### PR DESCRIPTION
As discussed in #503, I think this is prerequisite for any CLOS implementation with acceptable performance.

Because `conditions.lisp` depends on CLOS, we have to rely on early error definition for a longer duration. Therefore I changed it to be more informative, and use the printer if it is loaded.