### PR TITLE
cons micro-optimizations

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -65,8 +65,6 @@
 
 (defconstant t 't)
 (defconstant nil 'nil)
-(%js-vset "nil" nil)
-(%js-vset "t" t)
 
 (defmacro lambda (args &body body)
   `(function (lambda ,args ,@body)))

--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1238,21 +1238,21 @@
   (convert-to-bool `(instanceof ,x (internal |Cons|))))
 
 (define-builtin car (x)
-  `(call-internal |car| ,x))
+  `(property ,x "$$jscl_car"))
 
 (define-builtin cdr (x)
-  `(call-internal |cdr| ,x))
+  `(property ,x "$$jscl_cdr"))
 
 (define-builtin rplaca (x new)
   `(selfcall
      (var (tmp ,x))
-     (= (get tmp "car") ,new)
+     (= (property tmp "$$jscl_car") ,new)
      (return tmp)))
 
 (define-builtin rplacd (x new)
   `(selfcall
      (var (tmp ,x))
-     (= (get tmp "cdr") ,new)
+     (= (property tmp "$$jscl_cdr") ,new)
      (return tmp)))
 
 (define-builtin symbolp (x)
@@ -1341,8 +1341,8 @@
 			     (mapcar #'convert args)))))
 	  (var (tail ,(convert last)))
 	  (while (!= tail ,(convert nil))
-	    (method-call args "push" (get tail "car"))
-	    (= tail (get tail "cdr")))
+	    (method-call args "push" (get tail "$$jscl_car"))
+	    (= tail (get tail "$$jscl_cdr")))
 	  (return (method-call (if (=== (typeof f) "function")
 				   f
 				   (get f "fvalue"))

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -119,29 +119,22 @@ internals.checkArgs = function(args, n){
 // Lists
 
 internals.Cons = function (car, cdr) {
-  this.car = car;
-  this.cdr = cdr;
+  this['$$jscl_car'] = car;
+  this['$$jscl_cdr'] = cdr;
 };
 
-internals.car = function(x){
-  if (x === nil)
-    return nil;
-  else if (x instanceof internals.Cons)
-    return x.car;
-  else {
-    console.log(x);
-    throw new Error('CAR called on non-list argument');
-  }
-};
+Object.defineProperty(Object.prototype, "$$jscl_car", {
+  get: (function () { throw new Error('CAR called on non-list argument'); }),
+  set: (function () { throw new Error('RPLACA called on non-list argument'); }),
+});
 
-internals.cdr = function(x){
-  if (x === nil)
-    return nil;
-  else if (x instanceof internals.Cons)
-    return x.cdr;
-  else
-    throw new Error('CDR called on non-list argument');
-};
+Object.defineProperty(Object.prototype, "$$jscl_cdr", {
+  get: (function () { throw new Error('CDR called on non-list argument'); }),
+  set: (function () { throw new Error('RPLACD called on non-list argument'); }),
+});
+
+Object.defineProperty(internals.Cons.prototype, "$$jscl_car", { writable: true });
+Object.defineProperty(internals.Cons.prototype, "$$jscl_cdr", { writable: true });
 
 // Improper list constructor (like LIST*)
 internals.QIList = function(){
@@ -495,6 +488,13 @@ function runCommonLispScripts() {
     }
     progressivelyRunScripts();
 }
+
+// NIL and T
+
+nil = internals.intern("NIL", "COMMON-LISP");
+t = internals.intern("T", "COMMON-LISP");
+Object.defineProperty(nil, "$$jscl_car", { value: nil, writable: false });
+Object.defineProperty(nil, "$$jscl_cdr", { value: nil, writable: false });
 
 // Node Readline
 if (typeof module !== 'undefined' &&


### PR DESCRIPTION
This makes `car`/`cdr` faster, and makes `rplaca`/`rplacd` perform type check (which used to be missing).

After this patch, the sequence functions on lists become really fast (much faster than vector):
```
CL-USER> (let ((x (make-list 1000000))) (time (position 1 x)))
Execution took 0.023 seconds.
NIL
```
Compare to WECL (ECL on WASM), which runs this in 0.055 second.

Given how important these operations are for Lisps, I think the hacks are worth it, plus the absolute line of code shrink ;)