### PR TITLE
cleanup structures

### DIFF
--- a/src/compiler/compiler.lisp
+++ b/src/compiler/compiler.lisp
@@ -1439,8 +1439,16 @@
 ;;; Javascript FFI
 
 
-(define-builtin new ()
-  '(object))
+(define-raw-builtin new (&rest plist)
+  `(object
+    ,@(with-collect
+        (do ((tail plist (cddr tail)))
+            ((null tail))
+          (let ((key (car tail)))
+            (unless (stringp key)
+              (error 'type-error :datum key :expected-type 'string))
+            (collect key)
+            (collect (convert (cadr tail))))))))
 
 (define-builtin clone (x)
   `(method-call |Object| "assign" (object) ,x))

--- a/src/defstruct.lisp
+++ b/src/defstruct.lisp
@@ -80,13 +80,11 @@ Append numbers to symbol names to make them unique."
       (when constructor
         (setq constructor-expansion
               `(defun ,constructor (&key ,@slot-descriptions)
-                 (let ((obj (new)))
-                   (set-object-type-code obj :structure)
-                   (oset* ',name obj "structName")
-                   ,@(mapcar (lambda (p s)
-                               `(oset* ,(car s) obj ,p))
-                             property-names slot-descriptions)
-                   obj))))
+                 (new "dt_Name" :structure
+                      "structName" ',name
+                      ,@(mapcan (lambda (p s)
+                                  `(,p ,(car s)))
+                                property-names slot-descriptions)))))
 
       (when predicate
         (setq predicate-expansion

--- a/src/format.lisp
+++ b/src/format.lisp
@@ -31,15 +31,15 @@
 (/debug "loading format.lisp!")
 
 
-(defstruct (format-directive
+(def!struct (format-directive
 	    #+nil (:print-function %print-format-directive))
-  (string (error "Required argument") :type string)
-  (start (error "Required argument") :type (and unsigned-byte fixnum))
-  (end (error "Required argument") :type (and unsigned-byte fixnum))
-  (character (error "Required argument") :type character)
-  (colonp nil :type (member t nil))
-  (atsignp nil :type (member t nil))
-  (params nil :type list))
+  (string (error "Required argument") #+nil :type #+nil string)
+  (start (error "Required argument") #+nil :type #+nil (and unsigned-byte fixnum))
+  (end (error "Required argument") #+nil :type #+nil (and unsigned-byte fixnum))
+  (character (error "Required argument") #+nil :type #+nil character)
+  (colonp nil #+nil :type #+nil (member t nil))
+  (atsignp nil #+nil :type #+nil (member t nil))
+  (params nil #+nil :type #+nil list))
 
 (defun %print-format-directive (struct stream depth)
   (declare (ignore depth))
@@ -368,8 +368,8 @@
     (reverse results)))
 
 (defun expand-directive (directive more-directives)
-  (etypecase directive
-    (format-directive
+  (cond
+    ((format-directive-p directive)
      (let ((expander
 	     (aref *format-directive-expanders*
 		   (char-code (format-directive-character directive))))
@@ -379,9 +379,10 @@
 	   (funcall expander directive more-directives)
 	   (error 'format-error
 		  :complaint "Unknown directive."))))
-    (string
+    ((stringp directive)
      (values `(write-string ,directive stream)
-	     more-directives))))
+	     more-directives))
+    (t (error "Format directive with wrong type ~S" directive))))
 
 (defun expand-next-arg (&optional offset)
   (if (or *orig-args-available* (not *only-simple-args*))

--- a/src/structures.lisp
+++ b/src/structures.lisp
@@ -22,17 +22,6 @@
 
 (setq *structures* (make-hash-table))
 
-;;; list length 1
-(defun singleton-p (list)
-  (and (consp list) (null (cdr list))))
-
-;;; list length 2
-(defun doubleton-p (list)
-  (and (consp list)
-       (let ((rest (cdr list)))
-         (and (consp rest)
-              (null (cdr rest))))))
-
 ;;; properly list predicate from alexandria pkg
 (defun proper-list-p (object)
   "Returns true if OBJECT is a proper list."
@@ -61,40 +50,19 @@
                                     (1- max))))
         (t nil)))
 
-(defun das!lambda-list-args (from-boa-list)
-  (let* ((ll (parse-destructuring-lambda-list from-boa-list))
-         (r)
-         (req (lambda-list-reqvars ll))
-         (opt (dolist (it (lambda-list-optvars ll) (reverse r))
-                (push (list (optvar-variable it) (optvar-initform it)) r)))
-         (key (progn (setq r nil)
-                     (dolist (it (lambda-list-keyvars ll) (reverse r))
-                       (push (list (keyvar-variable it) (keyvar-initform it)) r))))
-         (aux (progn (setq r nil)
-                     (dolist (it (lambda-list-auxvars ll) (reverse r))
-                       (push (list (auxvar-variable it) (auxvar-initform it)) r)))
-
-           ))
-    (values req opt key aux)))
-
 (defun das!reassemble-boa-list (boa-list slots)
   (let ((new-boa-list nil)
-        (unmatch-p t) (key-p) (opt-p) (aux-p) (rest-p)
-        (lkw-p nil)
-        (sd))
+        (unmatch-p t)
+        (lkw-p nil))
     (flet ((%match (name d)
              (push (list name (dsd-slot-initform d)) new-boa-list))
            (%save (x) (push x new-boa-list))
-           (%switch (x)
-             (setq key-p (if (eq x '&key) t) opt-p (if (eq x '&optional) t)
-                   aux-p (if (eq x '&aux) t) rest-p (if (eq x '&rest) t)))
            (%find-slot-by-name (name)
              (find-if (lambda (slot) (if (eq name (dsd-slot-name slot)) slot)) slots)))
       (dolist (it boa-list (reverse new-boa-list))
         (cond
           ((atom it)
            (setq lkw-p (memq it '(&key &rest &optional &aux)))
-           (%switch it)
            (cond (unmatch-p
                   (%save it)
                   (if lkw-p (setq unmatch-p nil lkw-p nil)))
@@ -103,115 +71,78 @@
                            (setq lkw-p nil))
                           (t (%match it (%find-slot-by-name it)))))))
           ((listp it)
-           (setq sd (%find-slot-by-name (if (atom (car it)) (car it) (cadar it))))
-           (if (null sd)
-               ;; skip supplimentary lambda key var
-               (push it new-boa-list)
-               ;; else proceed slot
-               (cond
-                 ;;(name) -> (name default-from sd)
-                 ((proper-list-length-p it 1)
-                  (if (atom (car it))
-                      ;; (name)
-                      (%match (car it) (%find-slot-by-name (car it)))
-                      ;;((name name))
-                      (%match (car  it) (%find-slot-by-name (cadar it)))))
-                 ;;(name default) -> (name default)
-                 ;;(name default s-p) (name default s-p)
-                 ((or (proper-list-length-p it 2) (proper-list-length-p it 3))
-                  (%save  it) )))))))))
-
-(defun neq (x y) (not (eq x y)))
+           (let ((sd (%find-slot-by-name (if (atom (car it)) (car it) (cadar it)))))
+             (if (null sd)
+                 ;; skip supplimentary lambda key var
+                 (push it new-boa-list)
+                 ;; else proceed slot
+                 (cond
+                   ;;(name) -> (name default-from sd)
+                   ((proper-list-length-p it 1)
+                    (if (atom (car it))
+                        ;; (name)
+                        (%match (car it) (%find-slot-by-name (car it)))
+                        ;;((name name))
+                        (%match (car  it) (%find-slot-by-name (cadar it)))))
+                   ;;(name default) -> (name default)
+                   ;;(name default s-p) (name default s-p)
+                   ((or (proper-list-length-p it 2) (proper-list-length-p it 3))
+                    (%save  it) ))))))))))
 
 ;;; symbols concatenate
 (defun %symbolize (&rest rest)
-  (intern
-   (apply
-    'concat
-    (%lmapcar (lambda (x)
-              (typecase x
-                (symbol (symbol-name x))
-                (string x)
-                (t (error 'type-error :datum x :expected-type `(or symbol string)))))
-            rest))))
-
-;;; make check-type sign string
-;;; for debug identicale
-(defun das!struct-generate-signed (name)
-  (concat "(" (symbol-name name) ")"))
+  (intern (mapconcat #'string rest)))
 
 ;;; boa parse
-(defun das!parse-struct-lambda-list (from-boa-list)
-  (let* ((ll (parse-destructuring-lambda-list from-boa-list))
-         (r)
-         (req (lambda-list-reqvars ll))
-         (opt (dolist (it (lambda-list-optvars ll) (reverse r))
-                (push (list (optvar-variable it) (optvar-initform it)) r)))
-         (key (progn (setq r nil)
-                     (dolist (it (lambda-list-keyvars ll) (reverse r))
-                       (push (list (keyvar-variable it) (keyvar-initform it)) r))))
-         (aux (progn (setq r nil)
-                     (dolist (it (lambda-list-auxvars ll) (reverse r))
-                       (push (list (auxvar-variable it) (auxvar-initform it)) r)))))
-    (values req opt key aux)))
+(defun das!parse-constructor (name from-boa-list)
+  (let ((ll (parse-destructuring-lambda-list from-boa-list)))
+    (make-dsd-constructor
+     :name name :boa from-boa-list
+     :assigns (append (lambda-list-reqvars ll)
+                      (mapcar #'optvar-variable (lambda-list-optvars ll))
+                      (mapcar #'keyvar-variable (lambda-list-keyvars ll))
+                      (mapcar #'auxvar-variable (lambda-list-auxvars ll))))))
 
 (def!struct dsd
   name
   type
   named-p
-  seen-options
   conc-name
   predicate
   copier
   (initial-offset 0)
-  constructor
-  parent
+  constructors
   (childs '())
-  slots
-  (slot-nums 0)
+  slots                                 ; Direct slots
   include
-  inherit-slots
-  (inherit-slot-nums 0)
-  (instance-len 0)
-  storage
+  inherit-dsds ; List of inherited DSDs, from deepest ancestor to this DSD itself
   prototype
-  descriptor
   map-names)
 
 ;;; dd-slot slot descriptor
-(def!struct dsd-slot name accessor initform (type t) read-only)
-
-;;; structure storage descriptor.
-(def!struct dsd-storage-descriptor
-  leader  ;; -leader::= structure name, if structure is :named
-  n       ;; -n::= storage slots number include named & initial-offset
-  offset) ;; -offset::= some initial-offset
-
+(def!struct dsd-slot name initform (type t) read-only)
   
 ;;; structure-include
-(def!struct dsd-include name assigned inherited sd descriptor)
+(def!struct dsd-include name assigned inherited)
 ;;; name::= name included structure
-;;; inherited:: all slot-definitions from included structure-type-slots
-;;;             used for make-constructor == ((descriptor) slot-definitions*)
+;;; inherited:: DSD-INHERIT-DSDS of the included DSD
 ;;; assigned::= the names of the slots that were specified in the option :include
 ;;;             filled in when parsing (:include name slots*)
-;;; descriptor::= storage-descriptor from included structure-type-descriptor
-;;;             note: not used
-;;; sd::= parent slot-definitions without descriptor
-
   
 ;;; structure-prototype
 (def!struct dsd-prototype n map storage)
 
-;;; structure-constructor.
-(def!struct dsd-constructor name boa required optional key aux)
+;;; structure-constructor. boa can be :DEFAULT, which should be filled
+;;; later using DAS!RESOLVE-DEFAULT-CONSTRUCTOR and effective slots
+;;; information
+(def!struct dsd-constructor name boa assigns)
 
 #-jscl
-(defun %dsd-my-be-rewrite (name)
+(defun %dsd-maybe-rewrite (name)
   (declare (ignore name))
   t)
 #+jscl
-(defun %dsd-my-be-rewrite (name)
+(defun %dsd-maybe-rewrite (name)
   (let ((dd (get-structure-dsd name)))
     ;; structure not exists, so may be rewrite
     (or (null dd)
@@ -221,18 +152,9 @@
          ;; childs structures - not exists
          (null (dsd-childs dd))))))
 
-(defun %hash-table-keys (table)
-  (let ((keys nil))
-    (maphash
-     (lambda (k v)
-       (declare (ignore v))
-       (push k keys))
-     table)
-    keys))
-
-(defun das!include-possible-p (d1 d2)
-  (let ((s1 (%lmapcar 'dsd-slot-name (dsd-slots d1)))
-        (s2 (%lmapcar 'dsd-slot-name (dsd-slots d2))))
+(defun das!include-possible-p (self parent)
+  (let ((s1 (mapcar 'dsd-slot-name (dsd-slots self)))
+        (s2 (mapcar 'dsd-slot-name (mappend #'dsd-slots (dsd-inherit-dsds parent)))))
     (null (intersection s1 s2))))
 
 (deftype exists-structure-name ()	
@@ -284,7 +206,7 @@
       (multiple-value-bind (syntax-group winp)
           (cond ((= bit 0) (values 0 (and arg-p (proper-list-p args)))) 
                 ((< bit 3) (values 1 (and arg-p (not (cdr args)))))
-                (t         (values 2 (or (not args) (singleton-p args)))))
+                (t         (values 2 (or (not args) (proper-list-length-p args 1)))))
         (unless winp
           (if (proper-list-p option)
               (error "DEFSTRUCT option ~S ~D one argument" keyword
@@ -293,16 +215,16 @@
     (case keyword
       (:named (error "DEFSTRUCT option :named takes no arguments."))
       (:conc-name
-       (cond ((neq arg-p t) (setf (dsd-copier dd) nil))
+       (cond ((not arg-p) (setf (dsd-copier dd) nil))
              ((and arg-p (eq arg nil)) (setf (dsd-copier dd) nil))
              (t (setf (dsd-conc-name dd) (%conc-name-designator arg)))))
       (:copier
-       (cond ((neq arg-p t) (setf (dsd-copier dd) nil))
+       (cond ((not arg-p) (setf (dsd-copier dd) nil))
              ((and arg-p (eq arg nil)) (setf (dsd-copier dd) nil))
              (t (check-type arg sop-symbolic-name "(:copier)")
                 (setf (dsd-copier dd) arg)))  )
       (:predicate
-       (cond ((neq arg-p t)(setf (dsd-predicate dd) nil))
+       (cond ((not arg-p) (setf (dsd-predicate dd) nil))
              ((and arg-p (eq arg nil))(setf (dsd-predicate dd) nil))
              (t  (check-type arg sop-symbolic-name)
                  (setf (dsd-predicate dd) arg)))  )
@@ -317,14 +239,12 @@
             (error "Syntax error a DEFSTRUCT option ~s." option))
           (destructuring-bind (&optional (cname (%symbolize "MAKE-" (dsd-name dd)) cname-p)
                                  (boa nil boa-p)) args
-            (setq boa
-                  (cond ((not cname)
-                         (if boa-p (error "Syntax error a DEFSTRUCT option ~s." option))
-                         (if cname-p :disable))
-                        ((or (not boa-p) (null boa)) :default)
-                        (t boa)))
+            (cond ((not cname)
+                   (when boa-p (error "Syntax error a DEFSTRUCT option ~s." option)))
+                  ((or (not boa-p) (null boa))
+                   (setq boa :default)))
             (check-type cname (or (eql nil) (and symbol (not keyword))))
-            (push (cons cname boa) (dsd-constructor dd)))) ;;end :constructor
+            (push (cons cname boa) (dsd-constructors dd)))) ;;end :constructor
       (:type
        (cond ((memq arg '(vector list)) (setf (dsd-type dd) arg))
              ;; may be (:type (vector type))
@@ -333,12 +253,17 @@
       (otherwise (error "Unknown or unsupplied DEFSTRUCT option ~s." option)))
     seen))
 
+;;; The parsing happens in two passes. DAS!PARSE-OPTION normalize the
+;;; options and... store them (S-exprs) inside DD via
+;;; mutation. DAS!PARSE-DEFSTRUCT-OPTIONS then does another pass over
+;;; DD slots and set the final information (DSD-* structs) via
+;;; mutation.  It would be nice to get rid of so many mutations, but
+;;; it works for now.
 (defun das!parse-defstruct-options (options dd)
-  (let ((seen 0)
-        (named-p nil))
+  (let ((seen 0))
     (dolist (option options)
       (if (eq option :named)
-          (setf named-p t (dsd-named-p dd) t)
+          (setf (dsd-named-p dd) t)
           (setq seen
                 (das!parse-option
                  (cond ((consp option) option)
@@ -348,37 +273,24 @@
                  dd seen))))
     ;; prepare :constructors
     (let ((no-constructors nil)
-          (default nil)
           (default-p nil)
-          (custom nil)
-          (cname nil) (boa-list :default))
-      (dolist (cpair (dsd-constructor dd))
-        ;; bug: destructuring-bind not parsing (a . b)
-        (setq cname (car cpair)  boa-list (cdr cpair))
-        (cond ((not cname) (setq no-constructors t))
-              ((eq boa-list :default)
-               (if default-p
-                   (error "Multiple default constructor defined."))
-               (setq default cpair)
-               (setq default-p t))
-              ;; parse custom boa
-              (t (multiple-value-bind (req opt key aux)
-                     (das!parse-struct-lambda-list boa-list)
-                   (push
-                    (make-dsd-constructor :name cname :boa boa-list :required req
-                                          :optional opt   :key key :aux aux)
-                    custom)) )))
-      (setf (dsd-constructor dd)
-            ;; now dsd-constructor::= (default|nil custom|nil)
-            (if (eq no-constructors t)
-                (progn
-                  (when (or (not (null default)) (not (null custom)))
-                    (error "(:constructor nil) combined with other :constructro's."))
-                  nil)
-                (cond ((and (null default) (null custom))
-                       (setq default (cons (%symbolize "MAKE-" (dsd-name dd)) :default))
-                       (list default nil))
-                      (t (list default custom))))))
+          (constructors nil))
+      (dolist (cpair (dsd-constructors dd))
+        (destructuring-bind (cname . boa-list) cpair
+          (cond ((not cname) (setq no-constructors t))
+                ((eq boa-list :default)
+                 (if default-p
+                     (error "Multiple default constructor defined."))
+                 (push (make-dsd-constructor :name cname :boa :default) constructors)
+                 (setq default-p t))
+                ;; parse custom boa
+                (t (push (das!parse-constructor cname boa-list) constructors)))))
+      (when (and (eq no-constructors t) (not (null constructors)))
+        (error "(:constructor nil) combined with other :constructor's."))
+      (setf (dsd-constructors dd)
+            (or constructors
+                (list (make-dsd-constructor :name (%symbolize "MAKE-" (dsd-name dd))
+                                            :boa :default)))))
     (flet ((option-present-p (bit-name)
              (let ((opnames #(:include :initial-offset :type :conc-name :copier :predicate)))
                (logbitp (position bit-name opnames) seen))))
@@ -386,15 +298,12 @@
           (cond ((or (dsd-named-p dd) (null (dsd-type dd)))
                  ;; present structure is named or clos based
                  (let* ((parent-name (car (dsd-include dd)))
-                        (parent nil)
+                        (parent (if (exists-structure-p parent-name)
+                                    (get-structure-dsd parent-name)
+                                    (error "Structure ~s not exists." parent-name)))
                         (include-slots (cdr (dsd-include dd)))
-                        (include-name-table)
-                        (slot-name)
-                        (include))
-                   (if (exists-structure-p parent-name)
-                       (setq parent (get-structure-dsd parent-name))
-                       (error "Structure ~s not exists." parent-name))
-                   (setq include-name-table (dsd-map-names  parent))
+                        (include-name-table (dsd-map-names parent))
+                        (include (make-dsd-include :name parent-name)))
                    (unless (eql (dsd-type dd) (dsd-type parent))
                      (error "Incompatible structure type (~a ~a : ~a ~a)"
                             (dsd-name dd) (dsd-type dd)
@@ -402,23 +311,20 @@
                    (unless (or (dsd-named-p parent) (null (dsd-type parent)))
                      ;; included is unnamed
                      (error "Unnamed structure ~a not included." parent-name))
-                   (setq include (make-dsd-include :name parent-name))
                    (setf (dsd-include-assigned include)
                          ;; checking that the slot name is valid for the structure
-                         (let ((sd)
-                               (r))
-                           (dolist (it include-slots (reverse r))
-                             (typecase it
-                               (list (setq slot-name (car it)))
-                               (symbol (setq slot-name it))
-                               (t (raise-bad-include-slot it)))
-                             (unless (gethash slot-name include-name-table)
-                               (raise-bad-include-slot it))
-                             (setq sd (das!parse-struct-slot it))
-                             (push sd r))))
+                         (mapcar (lambda (it)
+                                   (let ((slot-name
+                                           (typecase it
+                                             (list (car it))
+                                             (symbol it)
+                                             (t (raise-bad-include-slot it)))))
+                                     (unless (gethash slot-name include-name-table)
+                                      (raise-bad-include-slot it)))
+                                   (das!parse-struct-slot it))
+                                 include-slots))
                    (setf (dsd-include dd) include)
-                   (setf (dsd-include-inherited include) (copy-tree (dsd-inherit-slots parent)))
-                   (setf (dsd-parent dd) parent-name)))
+                   (setf (dsd-include-inherited include) (copy-list (dsd-inherit-dsds parent)))))
                 (t (error "DEFSTRUCT :include option provide only for named or clos structure."))))
       ;; predicate, copier, conc-name for named lisp structure
       (unless (option-present-p :conc-name)
@@ -427,8 +333,9 @@
         (setf (dsd-copier dd) (%symbolize "COPY-" (dsd-name dd))))
       (when (memq (dsd-type dd) '(list vector))
         (when (option-present-p :predicate)
-          (unless named-p (error "DEFSTRUCT option :predicate provide only for named structure.~%")))
-        (when named-p 
+          (unless (dsd-named-p dd)
+            (error "DEFSTRUCT option :predicate provide only for named structure.~%")))
+        (when (dsd-named-p dd)
           (unless (option-present-p :predicate)
             (setf (dsd-predicate dd) (%symbolize (dsd-name dd) "-P")))))
       ;; initial-offset, predicate for clos structure
@@ -436,32 +343,29 @@
         (when (option-present-p :initial-offset)
           (warn "DEFSTRUCT option :INITIAL-OFFSET provided only for list/vector based structure.~%"))
         (unless (option-present-p :predicate)
-          (setf (dsd-predicate dd) (%symbolize (dsd-name dd) "-P")))))
-    (setf (dsd-seen-options dd) seen)
-    seen))
-
-(defun %atom-or-car (seq)
-  (mapcar
-   (lambda (x)
-     (if (atom x)
-         x
-         (if (listp (car x))
-             (error "Unsupported BOA form ~a." x)
-             (car x) )))
-   seq))
+          (setf (dsd-predicate dd) (%symbolize (dsd-name dd) "-P")))))))
 
 (defun das!canonicalize-slots (slots)
-  (let* ((dv)
-        (r (%lmapcar
-            (lambda (slot)
-              (list (dsd-slot-name slot)
-                    :initform (typecase (setq dv (dsd-slot-initform slot))
-                                (null nil)
-                                (symbol (list 'quote dv))
-                                (t dv))
-                    :initarg (intern (symbol-name (dsd-slot-name slot)) "KEYWORD")))
-            slots)))
-    r))
+  (mapcar
+   (lambda (slot)
+     (let ((dv (dsd-slot-initform slot)))
+       (list (dsd-slot-name slot)
+             :initform (typecase dv
+                         (null nil)
+                         (symbol (list 'quote dv))
+                         (t dv))
+             :initarg (intern (symbol-name (dsd-slot-name slot)) "KEYWORD"))))
+   slots))
+
+(defun das!resolve-default-constructor (constructor slots)
+  (when (eq :default (dsd-constructor-boa constructor))
+    (setf (dsd-constructor-boa constructor)
+          (list* '&key
+                 (mapcar (lambda (x)
+                           (list (dsd-slot-name x) (dsd-slot-initform x)))
+                         slots))
+          (dsd-constructor-assigns constructor)
+          (mapcar #'dsd-slot-name slots))))
 
 
 #+jscl
@@ -478,36 +382,36 @@
      (slot-value obj ',slot-name)))
 
 (defun das!%make-write-accessor-clos (name slot-name chk-t)
-  (let ((sign (das!struct-generate-signed name)))
-    `(defun (setf ,name) (value obj)
-       ,@(if chk-t (list `(check-type value ,chk-t ,sign)))
-       (setf (slot-value obj ',slot-name) value) )))
+  `(defun (setf ,name) (value obj)
+     ,@(when chk-t (list `(check-type value ,chk-t)))
+     (setf (slot-value obj ',slot-name) value)))
 
-(defun das!make-struct-accessors-clos (slots)
-  (let ((slot-name)
-        (result)
-        (chk-t)
-        (accessor-name))
+(defun das!make-struct-accessors-clos (slots conc-name)
+  (with-collect
     (dolist (it slots)
-      (setq accessor-name (dsd-slot-accessor it)
-            chk-t (dsd-slot-type it)
-            slot-name (dsd-slot-name it))
-      (push (das!%make-read-accessor-clos accessor-name slot-name) result)
-      (unless (dsd-slot-read-only it)
-        (push (das!%make-write-accessor-clos accessor-name slot-name chk-t) result)))
-    (reverse result)))
+      (let ((accessor-name (%slot-accessor-name it conc-name))
+            (chk-t (dsd-slot-type it))
+            (slot-name (dsd-slot-name it)))
+        (collect (das!%make-read-accessor-clos accessor-name slot-name))
+        (unless (dsd-slot-read-only it)
+          (collect (das!%make-write-accessor-clos accessor-name slot-name chk-t)))))))
+
+(defun das!make-constructor-check-types (slots assigned-slots)
+  (with-collect
+    (dolist (slot slots)
+      (when (and (memq (dsd-slot-name slot) assigned-slots)
+                 (dsd-slot-type slot)
+                 (not (dsd-slot-read-only slot)))
+        (collect `(check-type ,(dsd-slot-name slot) ,(dsd-slot-type slot)))))))
 
 ;;; each constructor from (:constructor) forms
 (defun das!make-clos-constructor (class-name constructor slots)
   ;; at this point slots::=  (append include-slots own-slots)
   ;;               constructor::= structure-constructor
+  (das!resolve-default-constructor constructor slots)
   (let* ((make-name (dsd-constructor-name constructor))
          (boa (dsd-constructor-boa constructor))
-         (req (dsd-constructor-required constructor))
-         (opt (%atom-or-car (dsd-constructor-optional constructor)))
-         (key (%atom-or-car (dsd-constructor-key constructor)))
-         (aux (%atom-or-car (dsd-constructor-aux constructor)))
-         (assigned-slots (append req opt key aux))
+         (assigned-slots (dsd-constructor-assigns constructor))
          (keyargs))
     ;; make :key arg pair
     (dolist (it assigned-slots)
@@ -515,20 +419,15 @@
       (push (intern (symbol-name it) "KEYWORD") keyargs)
       (push it keyargs))
     `(defun ,make-name ,(das!reassemble-boa-list boa slots)
-       ,@(loop
-           ;; check-type's for slots if :type assigned
-           for slot in slots
-           when (and (memq (dsd-slot-name slot) assigned-slots)
-                     (dsd-slot-type slot)
-                     (not (dsd-slot-read-only slot)))
-             collect `(check-type ,(dsd-slot-name slot) ,(dsd-slot-type slot) ))
+       ,@(das!make-constructor-check-types slots assigned-slots)
        (make-instance ',class-name ,@(reverse keyargs)))))
 
 ;;; make standard structure predicate and copier
-(defun das!make-structure-class-predicate (structure-name predicate-p)
-  `(defun ,predicate-p (obj)
-     (when (eq (class-name (class-of (class-of obj))) 'structure-class)
-       (eq (class-name (class-of obj)) ',structure-name))))
+(defun das!make-structure-class-predicate (structure-name predicate)
+  (when predicate
+    `(defun ,predicate (obj)
+       (when (eq (class-name (class-of (class-of obj))) 'structure-class)
+         (eq (class-name (class-of obj)) ',structure-name)))))
 
 #-jscl
 (defun das!clone-clos-base (object)
@@ -539,13 +438,14 @@
     (setf (std-instance-slots r) (list-to-vector (vector-to-list (std-instance-slots r))))
     r))
 
-(defun das!make-structure-class-copier (structure-name copier-p)
-  `(defun ,copier-p (obj)
-     (cond ((eq (class-name (class-of (class-of obj))) 'structure-class)
-            (if (eq (class-name (class-of obj)) ',structure-name)
-                (das!clone-clos-base obj)
-                (error "Object ~a not a structure ~a." obj ',structure-name)))
-           (t (error "Object ~a not a structure class." obj)))))
+(defun das!make-structure-class-copier (structure-name copier)
+  (when copier
+    `(defun ,copier (obj)
+       (cond ((eq (class-name (class-of (class-of obj))) 'structure-class)
+              (if (eq (class-name (class-of obj)) ',structure-name)
+                  (das!clone-clos-base obj)
+                  (error "Object ~a not a structure ~a." obj ',structure-name)))
+             (t (error "Object ~a not a structure class." obj))))))
 ;;; end CLOS section
 
 ;;; Lisp structure section
@@ -553,39 +453,38 @@
 (defun das!%make-read-accessor-vector (name index)
   `(defun ,name (obj) (storage-vector-ref obj ,index)))
 (defun das!%make-write-accessor-vector (name index chk-t)
-  (let ((sign (das!struct-generate-signed name)))
-    `(defun (setf ,name) (value obj)
-       ,@(if chk-t (list `(check-type value ,chk-t ,sign)))
-       (storage-vector-set! obj ,index value))))
+  `(defun (setf ,name) (value obj)
+     ,@(if chk-t (list `(check-type value ,chk-t)))
+     (storage-vector-set! obj ,index value)))
 (defun das!%make-read-accessor-list (name index)
   `(defun ,name (obj)
      (nth ,index obj)) )
 (defun das!%make-write-accessor-list (name index chk-t)
-  (let ((sign (das!struct-generate-signed name)))
-    `(defun (setf ,name) (value obj)
-       ,@(if chk-t (list `(check-type value ,chk-t ,sign)))
-       (rplaca (nthcdr ,index obj) value) )))
+  `(defun (setf ,name) (value obj)
+     ,@(if chk-t (list `(check-type value ,chk-t)))
+     (rplaca (nthcdr ,index obj) value) ))
 
-(defun das!make-struct-accessors-lv (storage-type hash slots)
-  (let ((index)
-        (result)
-        (chk-t)
-        (accessor-name)
-        (fn-read 'das!%make-read-accessor-vector)
+(defun %slot-accessor-name (slot conc-name)
+  (if conc-name
+      (%symbolize conc-name (dsd-slot-name slot))
+      (dsd-slot-name slot)))
+
+(defun das!make-struct-accessors-lv (storage-type hash slots conc-name)
+  (let ((fn-read 'das!%make-read-accessor-vector)
         (fn-write 'das!%make-write-accessor-vector))
     (cond ((eql storage-type 'list)
            (setq fn-read 'das!%make-read-accessor-list)
            (setq fn-write 'das!%make-write-accessor-list)))
-    (dolist (it slots)
-      (setq accessor-name (dsd-slot-accessor it)
-            chk-t (dsd-slot-type it)
-            index (gethash (dsd-slot-name it) hash))
-      (unless index
-        (error "Hash malformed : slot-name ~a accessor ~a" (dsd-slot-name it) accessor-name))     
-      (push (funcall fn-read accessor-name index) result)
-      (unless (dsd-slot-read-only it)
-        (push (funcall fn-write accessor-name index chk-t) result)))
-    (reverse result)))
+    (with-collect
+      (dolist (it slots)
+        (let ((accessor-name (%slot-accessor-name it conc-name))
+              (chk-t (dsd-slot-type it))
+              (index (gethash (dsd-slot-name it) hash)))
+          (unless index
+            (error "Hash malformed : slot-name ~a accessor ~a" (dsd-slot-name it) accessor-name))
+          (collect (funcall fn-read accessor-name index))
+          (unless (dsd-slot-read-only it)
+            (collect (funcall fn-write accessor-name index chk-t))))))))
 
 ;;; PREDICATE
 ;;;    A predicate can be defined only if the structure is named;
@@ -596,11 +495,8 @@
     (when (and (memq storage-type '(vector list)) (not leader-p))
       (warn "predicate ~a unsupplied for unnamed vector/list structure " predicate)
       (return-from das!make-struct-predicate nil))
-    (let* ((imap 0))
-      (dolist (cell (dsd-prototype-map prototype))
-        (if (eql cell -3)
-            (return))
-        (incf imap))
+    (let ((imap (or (position -3 (dsd-prototype-map prototype))
+                    (error "BUG: no self leader tag in DSD-PROTOTYPE ~a" prototype))))
       (cond ((eql 'vector storage-type)
              `(defun ,predicate (obj)
                 (and (storage-vector-p obj)
@@ -628,174 +524,70 @@
 
 ;;; CONSTRUCTORS
 (defun das!make-constructor-lv-for (prototype storage-type constructor slots)
+  (das!resolve-default-constructor constructor slots)
   (let* ((make-name (dsd-constructor-name constructor))
          (boa (dsd-constructor-boa constructor))
-         (req (dsd-constructor-required constructor))
-         (opt (%atom-or-car (dsd-constructor-optional constructor)))
-         (key (%atom-or-car (dsd-constructor-key constructor)))
-         (aux (%atom-or-car (dsd-constructor-aux constructor)))
-         (assigned-slots (append req opt key aux))
-         (default-slots
-           (set-difference (%lmapcar 'dsd-slot-name slots)
-                           (remove nil assigned-slots)))
-         (signed (das!struct-generate-signed make-name))
-         (storage)
-         (protos (dsd-prototype-storage prototype))
-         (map-position 0)
-         (sym))
-    (dolist (it (dsd-prototype-map prototype))
-      (cond ((eql it -1)
-             (push nil storage))
-            ((eql it -2)
-             (setq sym (nth map-position protos))
-             (push `',sym storage))
-            ((eql it -3)
-             (setq sym (nth map-position protos))
-             (push `',sym storage))
-            (t (setq sym (nth map-position protos))
-               (let (default)
-                 (cond ((memq sym default-slots)
-                        (setq default (find sym slots :key #'dsd-slot-name))
-                        (push (dsd-slot-initform default) storage))
-                       (t (push (nth map-position protos) storage))))))
-      (incf map-position))
-    (setq storage (reverse storage))
+         (assigned-slots (dsd-constructor-assigns constructor))
+         (default-slots (set-difference (mapcar 'dsd-slot-name slots) assigned-slots))
+         (storage
+           (mapcar (lambda (it sym)
+                     (cond ((eql it -1) nil)
+                           ((or (eql it -2) (eql it -3)) `',sym)
+                           ((memq sym default-slots)
+                            (dsd-slot-initform (find sym slots :key #'dsd-slot-name)))
+                           (t sym)))
+                   (dsd-prototype-map prototype)
+                   (dsd-prototype-storage prototype))))
     `(defun ,make-name ,(das!reassemble-boa-list boa slots)
-       ,@(loop
-           ;; check-type's for slots if :type assigned
-           for slot in slots
-           ;;when (and (not (member (structure-slot-name slot) default-slots))
-           ;;          (structure-slot-type slot))
-           when (and (memq (dsd-slot-name slot) assigned-slots)
-                     (dsd-slot-type slot)
-                     (not (dsd-slot-read-only slot)))
-             collect `(check-type ,(dsd-slot-name slot) ,(dsd-slot-type slot) ,signed))
+       ,@(das!make-constructor-check-types slots assigned-slots)
        ;; and prototype into required form
        (,storage-type ,@storage))))
 
-;;; generating structure constructors for list-vector storage 
-(defun %update-include-slots (slots asis)
-  (let (sname sval)
+;;; Compute list of effective slots for DD, include inherited slots,
+;;; and handle assigned initform in (:include name slots*) options
+(defun das!effective-slots (dd)
+  (let ((asis (and (dsd-include dd) (dsd-include-assigned (dsd-include dd))))
+        (slots (mapcar #'copy-dsd-slot (mappend #'dsd-slots (dsd-inherit-dsds dd)))))
+    ;; TODO: check assigned options like :TYPE and :READONLY
     (dolist (a asis)
-      (cond ((dsd-slot-p a)
-             (setq sname (dsd-slot-name a) sval (dsd-slot-initform a))
-             (map 'nil 
-                  (lambda (slot)
-                    (cond ((eq (dsd-slot-name slot) sname)
-                           (if (dsd-slot-type slot)
-                               (unless (typep sval (dsd-slot-type slot))
-                                 (error 'type-error :datum a :expected-type (dsd-slot-type slot))))
-                           (setf (dsd-slot-initform slot) sval))))
-                  slots)))))
-  slots)
-
-(defun das!make-struct-constructors (structure-type prototype storage-type constructors slots asis)
-  ;; structure-type::=structure-name
-  ;; constructors::= ((default)(custom))
-  (declare (ignore structure-type))
-  (let ((result)
-        #+nil (storage (dsd-prototype-storage prototype))
-        (slots (%update-include-slots slots asis)))
-    (if (null constructors)
-        (list nil)
-        (destructuring-bind (default custom) constructors
-          (when custom
-            (dolist (constructor custom)
-              ;; specialized constructor
-              (push (das!make-constructor-lv-for  prototype storage-type constructor slots)
-                    result)))
-          ;; default make-constructor
-          (when default
-            ;; default::=(cname . :default)
-            (let ((boa
-                    (list* '&key
-                           (%lmapcar (lambda (x)
-                                     (list (dsd-slot-name x) (dsd-slot-initform x)))
-                                   slots)))
-                  (constructor))
-              (multiple-value-bind (req opt key) (das!parse-struct-lambda-list boa)
-                (setq constructor
-                      (make-dsd-constructor :name (car default)
-                                            :boa boa :required req :optional opt :key key)))
-              (push (das!make-constructor-lv-for prototype storage-type constructor slots)
-                    result)))))
-    result))
+      (let ((sname (dsd-slot-name a))
+            (sval (dsd-slot-initform a)))
+        (dolist (slot slots)
+          (when (eq (dsd-slot-name slot) sname)
+            (when (dsd-slot-type slot)
+              (unless (typep sval (dsd-slot-type slot))
+                (error 'type-error :datum a :expected-type (dsd-slot-type slot))))
+            (setf (dsd-slot-initform slot) sval)))))
+    slots))
 
 ;;; entry point for lisp base object's
-(defun %conc-accessor-names (slot conc-name)
-  (if conc-name
-      (setf (dsd-slot-accessor slot) (%symbolize conc-name (dsd-slot-name slot)))
-      (setf (dsd-slot-accessor slot) (dsd-slot-name slot)))
-  slot)
-
 (defun das!make-lisp-base-structure (dd)
-  (let ((slots)
-        (asis (if (dsd-include dd) (dsd-include-assigned (dsd-include dd))))
-        (conc-name (dsd-conc-name dd))
-        (q))
-    (setq slots
-          (if (dsd-inherit-slots dd)
-              ;; slots merged with parent slots
-              (dolist (i (dsd-inherit-slots dd) (reverse slots))
-                (mapcar (lambda (x) (push x slots)) (cdr i)))
-              ;; slots without parent slots
-              (dsd-slots dd)))
-    (mapcar (lambda (x) (%conc-accessor-names x conc-name)) slots)
-    (setq q
-          (append
-           (das!make-struct-constructors (dsd-name dd) (dsd-prototype dd) (dsd-type dd)
-                                         (dsd-constructor dd) slots asis)
-           (das!make-struct-accessors-lv  (dsd-type dd) (dsd-map-names dd) slots)
-           (list (das!make-struct-predicate  (dsd-prototype dd) (dsd-name dd) (dsd-type dd)
-                                             (dsd-named-p dd) (dsd-predicate dd)))
-           (list (das!make-struct-copier (dsd-name dd) (dsd-type dd) (dsd-named-p dd) (dsd-copier dd)))
-           (list
-            (if (and (dsd-type dd) (dsd-named-p dd)(dsd-predicate dd))
-                `(deftype ,(dsd-name dd) () '(satisfies ,(dsd-predicate dd)))
-                nil))))
-    (remove nil q)
-    ))
+  (let ((slots (das!effective-slots dd)))
+    (append
+     (mapcar (lambda (it)
+               (das!make-constructor-lv-for  (dsd-prototype dd) (dsd-type dd) it slots))
+             (dsd-constructors dd))
+     (das!make-struct-accessors-lv  (dsd-type dd) (dsd-map-names dd) slots (dsd-conc-name dd))
+     (list (das!make-struct-predicate  (dsd-prototype dd) (dsd-name dd) (dsd-type dd)
+                                       (dsd-named-p dd) (dsd-predicate dd)))
+     (list (das!make-struct-copier (dsd-name dd) (dsd-type dd) (dsd-named-p dd) (dsd-copier dd)))
+     (list
+      (if (and (dsd-type dd) (dsd-named-p dd) (dsd-predicate dd))
+          `(deftype ,(dsd-name dd) () '(satisfies ,(dsd-predicate dd)))
+          nil)))))
 
 ;;; entry point for clos base
 (defun das!make-standard-structure (dd)
   (let ((name (dsd-name dd))
-        (slots)
-        (asis (if (dsd-include dd) (dsd-include-assigned (dsd-include dd))))
-        (conc-name (dsd-conc-name dd))
-        (constructors (dsd-constructor dd))
-        (q))
-    (setq slots
-          (if (dsd-inherit-slots dd)
-              (dolist (i (dsd-inherit-slots dd) (reverse slots))
-                (mapcar (lambda (x) (push x slots)) (cdr i)))
-              (dsd-slots dd)))
-    (mapcar (lambda (x) (%conc-accessor-names x conc-name)) slots)
-    (setq slots (%update-include-slots slots asis))
-    (push (das!make-structure-class name (dsd-slots dd) (dsd-include dd)) q)
-    (dolist (it (das!make-struct-accessors-clos slots))
-      (push it q))
-    (if constructors
-        (destructuring-bind (default custom) constructors
-          (when custom
-            (dolist (constructor custom)
-              (push (das!make-clos-constructor name constructor slots) q)))
-          (when default
-            (let ((boa
-                    (list* '&key
-                           (mapcar (lambda (x)
-                                     (list (dsd-slot-name x) (dsd-slot-initform x)))
-                                   slots)))
-                  (constructor))
-              (multiple-value-bind (req opt key) (das!parse-struct-lambda-list boa)
-                (setq constructor
-                      (make-dsd-constructor :name (car default)
-                                            :boa boa :required req :optional opt :key key)))
-              (push (das!make-clos-constructor name constructor slots) q))) ))
-    (when (dsd-predicate dd)
-      (push (das!make-structure-class-predicate name (dsd-predicate dd)) q))
-    (when (dsd-copier dd)
-      (push (das!make-structure-class-copier name (dsd-copier dd)) q))
-    (reverse q)))
+        (slots (das!effective-slots dd)))
+    (append
+     (list (das!make-structure-class name (dsd-slots dd) (dsd-include dd)))
+     (mapcar (lambda (it)
+               (das!make-clos-constructor name it slots))
+             (dsd-constructors dd))
+     (das!make-struct-accessors-clos slots (dsd-conc-name dd))
+     (list (das!make-structure-class-predicate name (dsd-predicate dd)))
+     (list (das!make-structure-class-copier name (dsd-copier dd))))))
 
 ;;; DD BUNDLE
 ;;; parse slot definitions from rest das!struct
@@ -826,164 +618,94 @@
              (keyword (error "DEFSTRUCT slot ~S syntax error." slot)))
            (values name default type read-only)))
         (t (error " ~S is not a legal slot description." slot)))
-    (make-dsd-slot :name name :accessor name :initform default :type type :read-only read-only)))
-
-;;; compare include assigned and imherit slots
-;;; check only :type & :read-only tags
-;;; subtype (initform type) done it %update-include-slots 
-(defun das!compare-asins (assigned inherit)
-  (dolist (as assigned)
-    (map 'nil
-         (lambda (in)
-           ;; in - inherit slot from parent
-           ;; as -assigned slot from :include
-           (let ((seen 0))
-             (unless (subtypep (dsd-slot-type as) (dsd-slot-type in))
-               (setq seen (logior seen (ash 1 0))))
-             (unless (eq (dsd-slot-read-only as) (dsd-slot-read-only in))
-               (setq seen (logior seen (ash 1 0))))
-             (if (> seen 0)
-                 (multiple-value-bind (tag datum expected)
-                     (case seen
-                       (1 (values "type" (dsd-slot-type as) (dsd-slot-type in)))
-                       (3 (values "read-only" (dsd-slot-read-only as) (dsd-slot-read-only in)))
-                       (otherwise "Panic" as in))
-                   (error "Incompatible ~a tag ~a ~a." tag datum expected)))))
-         inherit)))
+    (make-dsd-slot :name name :initform default :type type :read-only read-only)))
 
 ;;; check duplicate & identical slot names
 (defun das!parse-struct-slots (dd slots)
   (let* ((sd (mapcar 'das!parse-struct-slot slots))
          (raw (mapcar #'dsd-slot-name sd))
-         (parent (dsd-include dd))
-         (inherit)
          (clear (remove-duplicates raw)))
-    (if (/= (length raw) (length clear)) (error "Duplicate slot names ~a" raw))
-    ;; check identical names
-    (when parent
-      ;; parent slots without descriptor
-      (setq inherit (rest (dsd-include-inherited parent)))
-      (let ((dup (intersection raw (mapcar #'dsd-slot-name inherit))))
-        (if (not (null dup))
-            (error "Have the some slot names ~a." dup)))
-      (das!compare-asins (dsd-include-assigned (dsd-include dd)) inherit))
-    (setf (dsd-slots dd) sd
-          (dsd-slot-nums dd) (length sd))))
-
-;;;  update structure slots
-;;;  => (slots-with-accessor-names)
-(defun das%update-accessor-names (conc-name slots)
-      (dolist (slot slots)
-        (setf (dsd-slot-accessor slot)
-              (%symbolize conc-name (dsd-slot-name slot)))))
+    (when (/= (length raw) (length clear)) (error "Duplicate slot names ~a" raw))
+    (setf (dsd-slots dd) sd)))
 
 ;;; compute structure storage
 ;;; make prototype
 ;;;  compute storage prototype for structure list-vector storage base
 ;;;
-;;;  das!compute-storage-prototype &key include self
-;;;    include::= (descriptor slots)
-;;;    self:: (descriptor slots)
-;;;    descriptor::= structure-storage-descriptor
-;;;    slots::= (structure-slot*)
+;;;  das!compute-storage-prototype dd-list
+;;;    dd-list ::= {inherited-dsd}* self-dsd
 ;;; => (n-cells map prototype)
 ;;;     n-cells ::= length of structure storage
 ;;;     map::= tag*
-;;;     tag::= offset-tag | leader-tag | slot-position
+;;;     tag::= offset-tag | leader-tag |leader-self-tag | slot-position
 ;;;     offset-tag::= -1
 ;;;     leader-tag::= -2
+;;;     leader-self-tag::= -3
 ;;;     slot-position::= non-negative-integer
-;;;     prototype::= (offset-cells|leader-cell sn* )*
-;;;     offset-cells::= offset-tag *initial-offest | nothing if :initial-offset unused
-;;;     leader-cell::= real structure-name | nothing if :named unused
+;;;     prototype::= {offset-cells* leader-cell? sn*}*
+;;;     offset-cells::= offset-tag *initial-offest (nothing if :initial-offset unused)
+;;;     leader-cell::= real structure-name (nothing if :named unused)
 ;;;     sn::= real slot-name
 ;;; for 
 ;;; (das!struct-storage-generate-prototype
-;;;                  :include '(((binop nil 2)(binop-a nil nil nil)(binop-b nil nil nil))
-;;;                             ((maps nil 3) (maps-a nil nil nil)(maps-b nil nil nil)))
-;;;                  :self '(((pas nil 0) (pas-a nil nil nil)(pas-b nil nil nil))))
+;;;   (list (... :name binop :named-p t :initial-offset 2
+;;;              :slots ((binop-a nil nil nil)(binop-b nil nil nil)))
+;;;         (... :name maps :named-p t :initial-offset 3
+;;;              :slots ((maps-a nil nil nil)(maps-b nil nil nil)))
+;;;         (... :name pas :named-p t :initial-offset 0
+;;;              :slots ((pas-a nil nil nil)(pas-b nil nil nil)))))
 ;;;  from  (defstruct (pas :named (:include maps) pas-a pas-b pas-c))
 ;;;
 ;;;  n-cells::= 14
-;;;  map::=       (-1 -1  -2     3       4       -1  -1  -1  -2   9      10     -2  12    13)
+;;;  map::=       (-1 -1  -2     3       4       -1  -1  -1  -2   9      10     -3  12    13)
 ;;;  prototype::= (NIL NIL BINOP BINOP-A BINOP-B NIL NIL NIL MAPS MAPS-A MAPS-B PAS PAS-A PAS-B))
 ;;;
-(defun %storage-generate-prototype (d &optional storage (n-cell 0) i-map)
-  (let ((descriptor)(slots)(offset))
-    (dolist (it d)
-      (setq descriptor (car it) slots (rest it))
-      (setq offset (dsd-storage-descriptor-offset descriptor))
-      (dotimes (i offset)
-        (push nil storage)
-        (push -1 i-map)
-        (incf n-cell))
-      (when (dsd-storage-descriptor-leader descriptor)
-        (push (dsd-storage-descriptor-leader descriptor) storage)
-        (push -2 i-map)
-        (incf n-cell)) 
-      (dolist (slot slots)
-        (push (dsd-slot-name slot) storage)
-        (push n-cell i-map)
-        (incf n-cell))))
-  (list n-cell i-map storage))
 
-;;;  compute storage prototype for structure list-vector storage base
-(defun das%compute-storage-prototype (&key include self)
-  (destructuring-bind (n-cells-1 i-map-1 i-storage-1)
-      (%storage-generate-prototype include)
-    (destructuring-bind (n-cells-2 i-map-2 i-storage-2)
-        (%storage-generate-prototype self i-storage-1  n-cells-1 i-map-1)
-      (let ((icell 0))
-        (dolist (cell i-map-2)
-          (if (eql cell -2)
-              (progn (setf (nth icell i-map-2) -3) (return)))
-          (incf icell)))
-      (make-dsd-prototype :n n-cells-2 :map (reverse i-map-2) :storage (reverse i-storage-2)))))
+;;;  compute storage prototype from the descriptor list in DSD-INHERIT-DSDS
+(defun das%compute-storage-prototype (dd-list)
+  (let (storage (n-cell 0) i-map)
+    (dolist (it dd-list)
+      (let ((slots (dsd-slots it))
+            (offset (dsd-initial-offset it)))
+        (dotimes (i offset)
+          (push nil storage)
+          (push -1 i-map)
+          (incf n-cell))
+        ;; store tag for named structure
+        (when (dsd-named-p it)
+          (push (dsd-name it) storage)
+          (push -2 i-map)
+          (incf n-cell))
+        (dolist (slot slots)
+          (push (dsd-slot-name slot) storage)
+          (push n-cell i-map)
+          (incf n-cell))))
+    ;; Change map of the tag of this structure type itself to -3
+    (let ((icell 0))
+      (dolist (cell i-map)
+        (if (eql cell -2)
+            (progn (setf (nth icell i-map) -3) (return)))
+        (incf icell)))
+    (make-dsd-prototype :n n-cell :map (reverse i-map) :storage (reverse storage))))
 
 ;;; compute structure-type-hash
 ;;; => hash-table (slot-name : storage position)
 (defun das%compute-storage-hash (prototype)
-  (let ((hash (make-hash-table :test #'eql))
-        (slot-names
-          (remove nil
-                  (mapcar (lambda (x y)
-                            (if (>= x 0)
-                                ;; the slot-position, return symbol from y
-                                ;; cons name(y) position(x)
-                                (cons y x)
-                                nil))
-                          (dsd-prototype-map prototype)
-                          (dsd-prototype-storage prototype)))))
-    (dolist (pair slot-names)
-      (setf (gethash (car pair) hash) (cdr pair)))
+  (let ((hash (make-hash-table :test #'eql)))
+    (mapc (lambda (it sym)
+            (when (>= it 0)
+              ;; IT is slot position
+              (setf (gethash sym hash) it)))
+          (dsd-prototype-map prototype)
+          (dsd-prototype-storage prototype))
     hash))
-
-;;; merge two `slots` - from included structure & self slots
-#+nil
-(defun das%merge-slots (include own)
-  (append (structure-include-inherited include) own))
-
-;;; make Slot Order Descriptor &optional (q :zero) for first record
-;;; into dsd-inherit-slots (if structure has not include other structure)
-(defun das%make-sod (descriptor slots &optional q)
-  (let ((o (append (list descriptor)(mapcar (lambda (x) x) slots))))
-    (if q
-        (list o)
-        o)))
-
-;;; merge two sod's
-(defun das%merge-sod (&key new exists)
-  (let (r)
-    (dolist (it exists)
-      (push it r))
-    (push new r)
-    (reverse r)))
 
 ;;; finalize
 (defun das!finalize-structure (dd)
-  (let ((parent-name (dsd-parent dd)))
-    (when parent-name
-      (push (dsd-name dd) (dsd-childs (get-structure-dsd parent-name))))
+  (let ((include (dsd-include dd)))
+    (when include
+      (push (dsd-name dd)
+            (dsd-childs (get-structure-dsd (dsd-include-name include)))))
     #+nil
     (if (and (dsd-type dd) (dsd-named-p dd)(dsd-predicate dd))
         (%deftype (dsd-name dd)
@@ -994,48 +716,31 @@
 
 
 (defun das!defstruct-expand (name options slots)
-  (let ((dd) (include) (parent) (prototype) (descriptor)(standard) (lisp-type)
-        (to-inherit-slots))
-    #+jscl (unless (%dsd-my-be-rewrite name) (error "Structure ~a can't be overridden" name))
-    (setq dd (make-dsd :name name))
+  #+jscl (unless (%dsd-maybe-rewrite name) (error "Structure ~a can't be overridden" name))
+  (let ((dd (make-dsd :name name)))
     (das!parse-defstruct-options options dd)
-    (when (dsd-named-p dd)
-      (setf (dsd-named-p dd) (dsd-name dd))
-      (incf (dsd-instance-len dd)))
     (das!parse-struct-slots dd slots)
-    (incf (dsd-instance-len dd) (dsd-slot-nums dd))
-    (setq lisp-type (if (memq (dsd-type dd) '(list vector)) t nil))
-    (setq descriptor (make-dsd-storage-descriptor
-                      :leader (dsd-named-p dd)
-                      :n (dsd-instance-len dd)
-                      :offset (dsd-initial-offset dd)))
-    (cond ((dsd-parent dd)
-           (setq parent (get-structure-dsd (dsd-parent dd))
-                 include (dsd-include dd))
-           (unless (das!include-possible-p dd parent)
-             (error "This structures have overlapping names."))
-           ;; the structure included other structure
-           (setq to-inherit-slots (das%merge-sod
-                                   :new (das%make-sod descriptor (dsd-slots dd))
-                                   :exists (dsd-include-inherited include)))
-           ;; build storage prototype with included slots
-           (setq prototype (das%compute-storage-prototype
-                            :include (dsd-include-inherited include)
-                            :self (das%make-sod descriptor (dsd-slots dd) :zero))))
-          ;; structure without inherite
-          (t (setq to-inherit-slots (das%make-sod descriptor (dsd-slots dd) :zero)
-                   prototype (das%compute-storage-prototype
-                              :self (das%make-sod descriptor (dsd-slots dd) :zero)))))
-    (setf (dsd-map-names dd) (das%compute-storage-hash prototype)
-          (dsd-inherit-slots dd) (copy-tree to-inherit-slots)
-          (dsd-prototype dd) (if lisp-type (copy-dsd-prototype prototype) (list nil))
-          (dsd-descriptor dd) (copy-dsd-storage-descriptor descriptor))
-    (setq standard (if lisp-type
-                       (das!make-lisp-base-structure dd)
-                       (das!make-standard-structure dd)))
-    (das!finalize-structure dd)
-    standard
-    ))
+    ;; Handle inherited DSDs
+    (setf (dsd-inherit-dsds dd) (list dd))
+    (let ((include (dsd-include dd)))
+      (cond (include
+             (unless (das!include-possible-p dd (get-structure-dsd (dsd-include-name include)))
+               (error "Structure ~A have overlapping slots with included ~A."
+                      name (dsd-include-name include)))
+             ;; the structure included other structure
+             (setf (dsd-inherit-dsds dd) (append (dsd-include-inherited include) (list dd))))
+            (t (setf (dsd-inherit-dsds dd) (list dd)))))
+    ;; Compute prototype
+    (setf (dsd-prototype dd) (das%compute-storage-prototype (dsd-inherit-dsds dd))
+          (dsd-map-names dd) (das%compute-storage-hash (dsd-prototype dd)))
+    (let ((lisp-type (memq (dsd-type dd) '(list vector))))
+      ;; prototype is unused for object based structure
+      (when (null lisp-type)
+        (setf (dsd-prototype dd) (list nil)))
+      (das!finalize-structure dd)
+      (if lisp-type
+          (das!make-lisp-base-structure dd)
+          (das!make-standard-structure dd)))))
 
 (defmacro das!struct (name-and-options &rest slots)
   (let* ((name-and-options (ensure-list name-and-options))
@@ -1043,8 +748,7 @@
          (name (car name-and-options)))
     `(progn 
        ,@(das!defstruct-expand `,name `,options `,slots)
-       ',name 
-       )))
+       ',name)))
 
 #+jscl
 (defmacro defstruct (name-options &rest slots)

--- a/src/types-prelude.lisp
+++ b/src/types-prelude.lisp
@@ -50,19 +50,6 @@
       (if (eq item (car list)) (return list))
       (setq list (cdr list)))))
 
-;;; lightweight mapcar
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defun %lmapcar (fn list)
-    (let* ((ret-list (list nil))
-           (temp ret-list)
-           (res nil))
-      (while list
-        (setq res (funcall fn (car list))
-              list (cdr list))
-        (setf (cdr temp) (list res)
-              temp (cdr temp)))
-      (cdr ret-list))))
-
 (def!struct type-info name expand compound predicate)
 
 (defun %deftype-info (name &optional (create t))

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -125,7 +125,7 @@
 ;;; => class-cpl-list::= (name ... name)
 ;;;   name::= symbol
 (defun %class-cpl(class-name)
-  (%lmapcar #'class-name (class-precedence-list (find-class class-name nil))))
+  (mapcar #'class-name (class-precedence-list (find-class class-name nil))))
 
 ;;; c1-cpl::= symbol | cpl
 ;;; c2-name::= symbol | (find-class c2)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -93,6 +93,10 @@ accumulated, in the order."
       (aset v i x)
       (incf i))))
 
+(defun mappend (fn &rest lists)
+  (apply #'mapcan (lambda (&rest args) (copy-list (apply fn args)))
+         lists))
+
 (defmacro awhen (condition &body body)
   `(let ((it ,condition))
      (when it ,@body)))

--- a/tests/defstruct.lisp
+++ b/tests/defstruct.lisp
@@ -558,4 +558,14 @@
     (format nil "~S" (make-print-struct-test :a "hello" :b "world" :c 3))
     "#S(JSCL::PRINT-STRUCT-TEST :A \"hello\" :B \"world\" :C 3)"))
 
+;;; Don't overwrite DSDs for included structures
+
+(defstruct ow1-foo x)
+(defstruct (ow1-bar (:include ow1-foo (x 1))))
+(defstruct (ow1-baz (:include ow1-foo)))
+
+(test (and (eql nil (ow1-foo-x (make-ow1-foo)))
+           (eql 1 (ow1-foo-x (make-ow1-bar)))
+           (eql nil (ow1-foo-x (make-ow1-baz)))))
+
 ;;; EOF


### PR DESCRIPTION
This is prerequisite for my future plan of using JS objects for structures.

Unfortunately I'll have to `touch it` ;) The old implementation isn't written in the most reasonable (quite literally) Lisp, so I try to clean it up with best effort. Overall, I shrinked 250 lines from `structures.lisp`: 1053 -> 787, supposedly without any change of functionality.

The only new functionality that need reviewing:
- I extended `NEW` with PLIST arguments, so I can use it in `DEF!STRUCT` and in the future `DEFSTRUCT` more easily to initialize JS objects, like `(new "foo" 1 "bar" 2) -> {foo: 1, bar: 2}`.

Refactoring:
- Simplify (by removing and merging) some data structures. E.g.: 
  - There was a cryptic informally defined "SOD" object (which are in fact lists) that copies some information from inherited DSDs. I removed it and just keep a list of inherited DSDs.
  - Information in `DSD-STORAGE-DESCRIPTOR` is completely duplicate with `DSD`. I removed it and the code now just get `INITIAL-OFFSET` from `DSD`.
- The code was very imperative. I tried to remove many of the mutation, e.g. `das!effective-slots` instead of `%update-include-slots`
  - The elephant in the room is `das!parse-option`, `das!parse-defstruct-options` still works by mutation DSD. But it's at least more manageable.
- Replace some `DOLIST, SETQ, PUSH` which are just `MAPCAR` etc with `MAPCAR` etc.
- The old code has many `(let ((x) (y)) (setq x ...) (setq y ...) ...)` at `DEFUN` top level, that just binds variables to NIL then initialize them with `SETQ`, sometimes in deep inner scope. These are replaced with initializing in properly scoped `LET`.
- Some helper functions have duplicate functionality with existing function (e.g. `%lmapcar`), these are replaced with existing function
- Factor some duplicated logic into helper function