### PR TITLE
move worker logic out of jscl.js into separate application

### DIFF
--- a/jscl-worker-main.js
+++ b/jscl-worker-main.js
@@ -73,7 +73,7 @@ async function initialize() {
 }
 
 function loadJSCLWorker(sessionId) {
-  const jsclWorker = new Worker("jscl.js");
+  const jsclWorker = new Worker("jscl-worker.js");
   jsclWorker.onmessage = event => {
     const { string, stringclass } = event.data;
     jqconsole.Write(string, stringclass);

--- a/jscl-worker.html
+++ b/jscl-worker.html
@@ -8,6 +8,6 @@
     <div id="console"></div>
     <script src="jquery.js" type="text/javascript" charset="utf-8"></script>
     <script src="jqconsole.min.js" type="text/javascript" charset="utf-8"></script>
-    <script src="jscl-worker.js"></script>
+    <script src="jscl-worker-main.js"></script>
   </body>
 </html>

--- a/src/toplevel.lisp
+++ b/src/toplevel.lisp
@@ -323,6 +323,9 @@ no values if INPUT is empty."
 (when (string/= (%js-typeof |Deno|) "undefined")
   (push :deno *features*))
 
+(when (string/= (%js-typeof "WorkerGlobalScope") "undefined")
+  (push :web-worker *features*))
+
 (defun welcome-message (&key (html nil))
   (format t "Welcome to ~a (version ~a ~a)~%~%"
           (lisp-implementation-type)
@@ -398,8 +401,3 @@ no values if INPUT is empty."
 (defun require (name)
   (if (find :node *features*)
       (funcall (%js-vref "require") name)))
-
-
-(when (jscl::web-worker-p)
-  (jscl::initialize-web-worker))
-

--- a/worker/worker.lisp
+++ b/worker/worker.lisp
@@ -17,11 +17,6 @@
 
 (/debug "loading worker.lisp!")
 
-(defun web-worker-p ()
-  (and (string= (%js-typeof |document|) "undefined")
-       (string= (%js-typeof |module|)   "undefined")
-       (not (find :deno *features*))))
-
 (defvar *web-worker-session-id*)
 
 (defvar *web-worker-output-class* "jqconsole-output")
@@ -126,3 +121,5 @@
             (when (string= command "init")
               (setf *web-worker-session-id* sessionId)
               (web-worker-repl))))))
+
+(initialize-web-worker)


### PR DESCRIPTION
This way, if user just includes `jscl.js` in their worker, our worker REPL don't run.

This is response to https://github.com/jscl-project/jscl/issues/521#issuecomment-3725387882