### PR TITLE
move copying assets into jscl:bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ If you want to hack JSCL, you will have to download the repository
 
     git clone https://github.com/jscl-project/jscl.git
 
-*load* `jscl.lisp` in your Lisp, and call the bootstrap function to
-compile the implementation itself:
+Run `npm install` under the `jscl` directory. Then *load* `jscl.lisp`
+in your Lisp, and call the build-all function to compile the
+implementation itself:
 
-    (jscl:bootstrap)
+    (jscl:build-all)
 
 It will generate a `jscl.js` file in the top of the source tree. Now
 you can open `jscl.html` in your browser and use it. To use in Node,

--- a/jscl.lisp
+++ b/jscl.lisp
@@ -18,7 +18,8 @@
 
 (defpackage :jscl
   (:use :cl)
-  (:export #:bootstrap #:compile-application #:run-tests-in-host))
+  (:export #:bootstrap #:build-repls #:build-tests #:build-all
+           #:compile-application #:run-tests-in-host))
 
 (in-package :jscl)
 
@@ -112,24 +113,6 @@
     ("compile-file"  :both)
     ("load"          :target)))
 
-;;; List of static files to copy to *DIST-DIRECTORY*
-
-;;; Each item should be either SRC-PATH or (SRC-PATH DST-PATH).
-;;; SRC-PATH is relative to *BASE-DIRECTORY* and DST-PATH is relative
-;;; to *DIST-DIRECTORY*. If DST-PATH is not provided, default to the
-;;; name/type components of SRC-PATH (directory nesting is
-;;; REMOVED). Unix namestrings are used for all paths and are parsed
-;;; with UIOP:PARSE-UNIX-NAMESTRING.
-(defvar *static-files*
-  '("web/index.html"
-    "web/style.css"
-    ("node_modules/jquery/dist/jquery.min.js" "jquery.js")
-    "node_modules/jq-console/lib/jqconsole.js"
-    ("worker/index.html" "worker.html" )
-    "worker/main.js"
-    "worker/service-worker.js"
-    "tests.html"))
-
 
 (defun source-pathname (filename &key (directory '(:relative "src")) (type nil) (defaults filename))
   (merge-pathnames
@@ -207,20 +190,7 @@
     (setq *environment* (make-lexenv))
     (setq *global-environment* *environment*)
     (setq *fn-info* '())
-    (uiop:run-program (list "npm" "install"
-                            "--prefix" (uiop:native-namestring *base-directory*))
-                      :output t
-                      :error-output t)
     (ensure-directories-exist *dist-directory*)
-    (dolist (it *static-files*)
-      (let* ((it (uiop:ensure-list it))
-             (src-file (uiop:parse-unix-namestring (car it)))
-             (dst-file (if (cadr it)
-                           (uiop:parse-unix-namestring (cadr it))
-                           (make-pathname :directory '(:relative)
-                                          :defaults src-file))))
-        (uiop:copy-file (merge-pathnames src-file *base-directory*)
-                        (merge-pathnames dst-file *dist-directory*))))
     (with-compilation-environment
       (with-open-file (out (merge-pathnames "jscl.js" *dist-directory*)
                            :direction :output
@@ -241,9 +211,32 @@
 
         (format out "})();~%")))
 
-    (report-undefined-functions)
+    (report-undefined-functions)))
+
+(defun copy-asset (src-path &optional dst-path)
+  "Copy static file from SRC-PATH to DST-PATH.
+SRC-PATH is relative to *BASE-DIRECTORY* and DST-PATH is relative to
+*DIST-DIRECTORY*. If DST-PATH is not provided, default to the
+name/type components of SRC-PATH (directory nesting is *removed*). Unix
+namestrings are used for all paths and are parsed with
+UIOP:PARSE-UNIX-NAMESTRING."
+  (let* ((src-path (uiop:parse-unix-namestring src-path))
+         (dst-path (if dst-path
+                       (uiop:parse-unix-namestring dst-path)
+                       (make-pathname :directory '(:relative)
+                                      :defaults src-path))))
+    (uiop:copy-file (merge-pathnames src-path *base-directory*)
+                    (merge-pathnames dst-path *dist-directory*))))
+
+(defun build-repls ()
+  (let ((*package* (find-package "JSCL"))
+        (*default-pathname-defaults* *base-directory*))
 
     ;; Web REPL
+    (copy-asset "web/index.html")
+    (copy-asset "web/style.css")
+    (copy-asset "node_modules/jquery/dist/jquery.min.js" "jquery.js")
+    (copy-asset "node_modules/jq-console/lib/jqconsole.js")
     (compile-application (list (source-pathname "repl.lisp" :directory '(:relative "web")))
                          (merge-pathnames "jscl-web.js" *dist-directory*))
 
@@ -253,23 +246,35 @@
                          :shebang t)
 
     ;; Web worker REPL
+    (copy-asset "worker/index.html" "worker.html" )
+    (copy-asset "worker/main.js")
+    (copy-asset "worker/service-worker.js")
     (compile-application (list (source-pathname "worker.lisp" :directory '(:relative "worker")))
                          (merge-pathnames "jscl-worker.js" *dist-directory*))
 
     ;; Deno REPL
     (compile-application (list (source-pathname "repl.lisp" :directory '(:relative "deno")))
-                         (merge-pathnames "jscl-deno.js" *dist-directory*))
+                         (merge-pathnames "jscl-deno.js" *dist-directory*))))
 
-    ;; Tests
+(defun build-tests ()
+  (let ((*package* (find-package "JSCL"))
+        (*default-pathname-defaults* *base-directory*))
+
+    (copy-asset "tests.html")
     (compile-application
      `(,(source-pathname "tests.lisp" :directory nil)
-        ,@(directory (source-pathname "*" :directory '(:relative "tests") :type "lisp"))
-        ;; Loop tests
-        ,(source-pathname "validate.lisp" :directory '(:relative "tests" "loop") :type "lisp")
-        ,(source-pathname "base-tests.lisp" :directory '(:relative "tests" "loop") :type "lisp")
+       ,@(directory (source-pathname "*" :directory '(:relative "tests") :type "lisp"))
+       ;; Loop tests
+       ,(source-pathname "validate.lisp" :directory '(:relative "tests" "loop") :type "lisp")
+       ,(source-pathname "base-tests.lisp" :directory '(:relative "tests" "loop") :type "lisp")
 
-        ,(source-pathname "tests-report.lisp" :directory nil))
+       ,(source-pathname "tests-report.lisp" :directory nil))
      (merge-pathnames "tests.js" *dist-directory*))))
+
+(defun build-all (&optional verbose)
+  (bootstrap verbose)
+  (build-repls)
+  (build-tests))
 
 
 ;;; Run the tests in the host Lisp implementation. It is a quick way

--- a/make.sh
+++ b/make.sh
@@ -18,4 +18,4 @@ OPTIND=1
 # Unix timestamp of the commit we are building
 export SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)
 
-sbcl --load "$BASE/jscl.lisp" --eval "(jscl:bootstrap $VERBOSE)" --eval '(quit)'
+sbcl --load "$BASE/jscl.lisp" --eval "(jscl:build-all $VERBOSE)" --eval '(quit)'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,7 +1011,6 @@
     },
     "web": {
       "name": "@jscl/web",
-      "version": "0.8.2",
       "devDependencies": {
         "jq-console": "^2.13.2",
         "jquery": "^3.7.1"


### PR DESCRIPTION
This moves everything into `bootstrap` for now (including `npm install`).

It uses `--prefix` option of `npm` to avoid current directory quirks. @davazp I recommend you do the same with `git -C`.

We can discuss how to split `bootstrap` and whether we want to do it now or save it for later. From dev experience POV I think there are 3 sensible stages to split:
1. `npm install` and static assets (need to run when I modify these)
2. build `jscl.js` and all REPLs (when I want to make sure the system starts up sensibly, before getting into fixing all the tests).
3. build `tests.js`.

Conceptually 2 might be split into `jscl.js` itself and the REPLs, but I never had the need to just compile `jscl.js` (a new `jscl.js` likely require REPLs to be recompiled anyway, and I need the REPLs to sanity check the new `jscl.js`).