### PR TITLE
move early error definition into prelude.js, close #578

### DIFF
--- a/src/boot.lisp
+++ b/src/boot.lisp
@@ -438,17 +438,14 @@
 
 ;;; macro's
 
-;;; N.B. The following definition is functional after `string.lisp' is
-;;; loaded, and superseded after `conditions.lisp' is loaded.
-(defun %check-type-error (place value typespec string)
-   (error "Check type error.~%The value of ~s is ~s, is not ~a."
-          place value (if (null string) (format nil "a ~s" typespec) string)))
-
 (defmacro %check-type (place typespec &optional string)
   (let ((value (gensym)))
     `(do ((,value ,place ,place))
          ((!typep ,value ',typespec))
-       (setf ,place (%check-type-error ',place ,value ',typespec ,string)))))
+       (setf ,place (error 'check-type-error :datum ,value
+                                             :expected-type ',typespec
+                                             :place ',place
+                                             :description ,string)))))
 
 #+jscl
 (defmacro check-type (place typespec &optional string)
@@ -517,23 +514,6 @@
              t))
     (t
      (values nil nil))))
-
-;;; Early error definition.
-(defun %coerce-panic-arg (arg)
-  (if (fboundp 'prin1-to-string)
-      (concat (prin1-to-string arg) " ")
-      (cond ((symbolp arg) (concat "symbol: " (symbol-name arg) " "))
-            ((consp arg) (concat "cons: " (car arg)  " "))
-            ((numberp arg) (concat "number:" arg  " "))
-            (t "@ "))))
-
-;;; N.B. The following definition is functional after `string.lisp' is
-;;; loaded, and superseded after `conditions.lisp' is loaded.
-(defun error (fmt &rest args)
-  (%throw (lisp-to-js (apply #'concat "BOOT PANIC! "
-                             (string fmt)
-                             " "
-                             (mapcar #'%coerce-panic-arg args)))))
 
 ;;; print-unreadable-object
 (defmacro !print-unreadable-object ((object stream &key type identity) &body body)

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -125,6 +125,19 @@
 
 
 ;;; Conditions used in previous bootstrap process
+(%define-condition check-type-error (type-error)
+   ((place :initform nil
+           :initarg :place
+           :reader check-type-error-place)
+    (description :initform nil
+                 :initarg :description
+                 :reader check-type-error-description))
+   (:report (lambda (condition stream)
+              (format stream "The value of ~s is ~s, is not ~a."
+                      (check-type-error-place condition)
+                      (type-error-datum condition)
+                      (or (check-type-error-description condition)
+                          (format nil "a ~s" (type-error-expected-type condition)))))))
 (%define-condition package-error (error)
    ((package :initform nil
              :initarg :package
@@ -192,14 +205,6 @@
     ;;(format stream "~&ERROR: ~a~%" (type-of condition))
     (format t "~A: ~A" (class-name (class-of condition)) condition)
     nil))
-
-(defun %%check-type-error (place value typespec string)
-  (error 'simple-type-error
-         :datum value
-         :expected-type typespec
-         :format-control "Check type error.~%The value of ~s is ~s, is not ~a."
-         :format-arguments (list place value
-                                 (if (null string) (format nil "a ~s" typespec) string))))
 
 ;;; handlers
 (defvar *handler-bindings* nil)
@@ -304,7 +309,6 @@
   (fset 'make-condition #'%%make-condition)
   (fset 'signal #'%%signal)
   (fset 'warn #'%%warn)
-  (fset 'error #'%%error)
-  (fset '%check-type-error #'%%check-type-error))
+  (fset 'error #'%%error))
 
 ;;; EOF

--- a/src/prelude.js
+++ b/src/prelude.js
@@ -548,6 +548,13 @@ errorSym = internals.intern("ERROR");
 Object.defineProperty(nil, "$$jscl_car", { value: nil, writable: false });
 Object.defineProperty(nil, "$$jscl_cdr", { value: nil, writable: false });
 
+// Early error definition
+
+errorSym.fvalue = function earlyError(mv, ...args){
+  console.debug("BOOT PANIC! Arguments to ERROR:", ...args.map(internals.lisp_to_js));
+  throw "BOOT PANIC!";
+}
+
 // Node/Deno REPL
 if (
   typeof module !== "undefined" &&


### PR DESCRIPTION
Hope this makes our life better, enjoy :D

The JS early error definition simply feeds the argument array into `console.debug`, that is... this is more useful than pretty. But I suppose that's all what we need.