### PR TITLE
Prevent further code execution if serious-condition signalled while no handler bindings are installed

### DIFF
--- a/jscl.lisp
+++ b/jscl.lisp
@@ -163,7 +163,8 @@
      ("exports"       :target)
      ("describe"      :target))
     ("compile-file"  :both)
-    ("load"          :target)))
+    ("load"          :target)
+    ("time"          :both)))
 
 (defun get-files (file-list type dir)
   "Traverse FILE-LIST and retrieve a list of the files within which match

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -207,7 +207,11 @@
     nil))
 
 ;;; handlers
-(defvar *handler-bindings* nil)
+(defvar *handler-bindings* 
+        (list (cons 'serious-condition 
+                    (lambda (c) 
+                      (format-backtrace *trace-output* :from #'signal)
+                      (%%throw (jsstring (format nil "Unhandled serious condition ~A: ~A~%" (class-name (class-of c)) c)))))))
 
 (defmacro %%handler-bind (bindings &body body)
   (let ((install-handlers nil))


### PR DESCRIPTION
This PR improves the situation where, when executing code without a proper handler binding environment, calls to `(error ...)` do not actually stop execution, but simply report errors and execution continues.