### PR TITLE
Fix MOP printer

### DIFF
--- a/src/clos/mop-utils.lisp
+++ b/src/clos/mop-utils.lisp
@@ -31,7 +31,7 @@
              (push "#(..) " result))
             ((or (numberp place)
                  (symbolp place))
-             (push (format nil "~A " place) result)
+             (push (format nil "~A " place) result))
             ((stringp place)
              (push (concat place " ") result))
             (t (push "@ " result))))

--- a/src/clos/mop-utils.lisp
+++ b/src/clos/mop-utils.lisp
@@ -31,7 +31,7 @@
              (push "#(..) " result))
             ((or (numberp place)
                  (symbolp place))
-             (push (concat (string place) " ") result))
+             (push (format nil "~A " place) result)
             ((stringp place)
              (push (concat place " ") result))
             (t (push "@ " result))))


### PR DESCRIPTION
Fix printing MOP objects with number contained slots:

```
CL-USER> (defclass x () ((a :initform 100)))
#<STANDARD-CLASS X>
CL-USER> (print (make-instance 'x))

TYPE-ERROR: 100 is not a (OR STRING SYMBOL CHARACTER).
SIMPLE-ERROR: internals.symbolValue(...).Error.captureStackTrace is not a function
ERROR[!]: internals.symbolValue(...).Error.captureStackTrace is not a function
JSCL_USER_BACKTRACE/l2439.fvalue<@https://jscl-project.github.io/jscl.js:27047:44
JSCL_USER_BACKTRACE/l2439.fvalue<@https://jscl-project.github.io/jscl.js:27063:3
JSCL_USER_BACKTRACE@https://jscl-project.github.io/jscl.js:27064:3
JSCL_USER_FORMATBACKTRACE/l2447.fvalue<@https://jscl-project.github.io/jscl.js:27092:55
JSCL_USER_FORMATBACKTRACE/l2447.fvalue<@https://jscl-project.github.io/jscl.js:27118:3
JSCL_USER_FORMATBACKTRACE@https://jscl-project.github.io/jscl.js:27119:3
JSCL_USER_NIL@https://jscl-project.github.io/jscl-web.js:179:5
JSCL_USER_SIGNAL/<@https://jscl-project.github.io/jscl.js:42946:42
JSCL_USER_SIGNAL/<@https://jscl-project.github.io/jscl.js:42947:3
JSCL_USER_SIGNAL/<@https://jscl-project.github.io/jscl.js:42948:3
JSCL_USER_SIGNAL/l4333.fvalue<@https://jscl-project.github.io/jscl.js:42952:3
JSCL_USER_SIGNAL/l4333.fvalue<@https://jscl-project.github.io/jscl.js:42954:3
JSCL_USER_SIGNAL/l4333.fvalue<@https://jscl-project.github.io/jscl.js:42955:3
JSCL_USER_SIGNAL/l4333.fvalue<@https://jscl-project.github.io/jscl.js:42956:3
JSCL_USER_SIGNAL@https://jscl-project.github.io/jscl.js:42957:3
JSCL_USER_ERROR/l4330.fvalue<@https://jscl-project.github.io/jscl.js:43039:7
JSCL_USER_ERROR/l4330.fvalue<@https://jscl-project.github.io/jscl.js:43042:3
JSCL_USER_ERROR@https://jscl-project.github.io/jscl.js:43043:3
JSCL_USER_TOPLEVEL/JSCL_USER_NIL/</<@https://jscl-project.github.io/jscl-web.js:206:10
JSCL_USER_TOPLEVEL/JSCL_USER_NIL/<@https://jscl-project.github.io/jscl-web.js:208:4
internals.bindSpecialBindings@https://jscl-project.github.io/jscl.js:542:12
JSCL_USER_TOPLEVEL/JSCL_USER_NIL/<@https://jscl-project.github.io/jscl-web.js:160:40
JSCL_USER_TOPLEVEL/JSCL_USER_NIL/<@https://jscl-project.github.io/jscl-web.js:210:3
JSCL_USER_TOPLEVEL/JSCL_USER_NIL/<@https://jscl-project.github.io/jscl-web.js:213:4
JSCL_USER_TOPLEVEL/JSCL_USER_NIL/<@https://jscl-project.github.io/jscl-web.js:234:4
JSCL_USER_NIL@https://jscl-project.github.io/jscl-web.js:237:3
JQConsole.prototype._HandleEnter/continuation@https://jscl-project.github.io/jqconsole.js:1071:25
JQConsole.prototype._HandleEnter@https://jscl-project.github.io/jqconsole.js:1081:20
JQConsole.prototype._HandleKey@https://jscl-project.github.io/jqconsole.js:951:18
bind/<@https://jscl-project.github.io/jqconsole.js:10:59
dispatch@https://jscl-project.github.io/jquery.js:2:40035
add/v.handle@https://jscl-project.github.io/jquery.js:2:38006
```