### PR TITLE
Fix subclassp for T class

### DIFF
--- a/src/clos/std-object.lisp
+++ b/src/clos/std-object.lisp
@@ -244,7 +244,8 @@
 
 ;;; subclassp and sub-specializer-p
 (defun subclassp (c1 c2)
-  (not (null (find c2 (class-precedence-list c1)))))
+  (or (equal c1 c2)
+      (not (null (find c2 (class-precedence-list c1))))))
 
 (defun sub-specializer-p (c1 c2 c-arg)
   (let ((cpl (class-precedence-list c-arg)))


### PR DESCRIPTION
The class `T` has no superclassess, so internal CLOS function `SUBCLASSP`, which is involved in appropriate method computation, returns `NIL` if both arguments are `T`:

```
CL-USER> (defclass c1 () ())

#<STANDARD-CLASS C1>
CL-USER> (jscl::subclassp (find-class 'c1) (find-class 'c1))
T
CL-USER> (jscl::subclassp (find-class T) (find-class T))
NIL
```